### PR TITLE
fix(parser): Validate the reported diagnostic messages

### DIFF
--- a/src/cxx/preprocessor.cc
+++ b/src/cxx/preprocessor.cc
@@ -1731,4 +1731,11 @@ std::string_view Preprocessor::getTextLine(const Token &token) const {
   return textLine;
 }
 
+std::string_view Preprocessor::getTokenText(const Token &token) const {
+  if (token.fileId() == 0) return std::string_view();
+  const SourceFile *file = d->sourceFiles_[token.fileId() - 1].get();
+  std::string_view source = file->source;
+  return source.substr(token.offset(), token.length());
+}
+
 }  // namespace cxx

--- a/src/cxx/preprocessor.h
+++ b/src/cxx/preprocessor.h
@@ -86,6 +86,8 @@ class Preprocessor {
 
   std::string_view getTextLine(const Token &token) const;
 
+  std::string_view getTokenText(const Token &token) const;
+
   void squeeze();
 
  private:

--- a/src/frontend/cli.cc
+++ b/src/frontend/cli.cc
@@ -145,6 +145,8 @@ std::vector<CLIOptionDescr> options{
      "Set the toolchain to 'linux', 'darwin' or 'windows'",
      CLIOptionDescrKind::kSeparated},
 
+    {"-verify", "Verify the diagnostic messages", &CLI::opt_verify},
+
     {"-v", "Show commands to run and use verbose output", &CLI::opt_v},
 
 };

--- a/src/frontend/cli.h
+++ b/src/frontend/cli.h
@@ -61,6 +61,7 @@ class CLI {
   bool opt_nostdincpp = false;
   bool opt_S = false;
   bool opt_c = false;
+  bool opt_verify = false;
   bool opt_v = false;
 
   bool checkTypes() const { return opt_ir_dump || opt_S || opt_c; }


### PR DESCRIPTION
When `cxx-frontend` is invoked with the option `-verify` the reported
diagnostic messages are validated against the expected diagnostics
defined using comment-directives matchig the following regex:

```
  //\s*expected-(error|warning)(@[+-]?\d+)?\s*{{.+}}
```

Implements #38