### PR TITLE
fix(ci): Add support for multi-config cmake projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,9 @@ jobs:
           cmake --build build
 
       - name: Test
+        working-directory: build
         run: |
-          cmake --build build --target test
+          ctest -v
 
   build-windows:
     runs-on: windows-latest
@@ -43,11 +44,20 @@ jobs:
           path: ~\AppData\Local\vcpkg\archives
           key: vcpkg-cache
 
+      - name: Install unit tests requirements
+        run: |
+          pip install -r tests\unit_tests\requirements.txt
+
       - name: Build
         run: |
           mkdir build
           cmake -Bbuild -DCMAKE_TOOLCHAIN_FILE=C:\Vcpkg\scripts\buildsystems\vcpkg.cmake .
-          cmake --build build
+          cmake --build build --config Release
+
+      - name: Test
+        working-directory: build
+        run: |
+          ctest -v -C Release
 
   build-emscripten:
     runs-on: ubuntu-20.04

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -48,7 +48,7 @@ file(READ lit.site.cfg.py.in lit_cfg_in)
 string(CONFIGURE "${lit_cfg_in}" lit_cfg @ONLY)
 
 file(GENERATE
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+    OUTPUT $<CONFIG>.lit.site.cfg.py
     CONTENT "${lit_cfg}")
 
 add_subdirectory(preprocessor)

--- a/tests/unit_tests/preprocessor/CMakeLists.txt
+++ b/tests/unit_tests/preprocessor/CMakeLists.txt
@@ -18,4 +18,4 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 add_test(NAME preprocessor
-    COMMAND lit::tool -v ${CMAKE_CURRENT_BINARY_DIR})
+    COMMAND lit::tool --config-prefix $<CONFIG>.lit -v ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
Also, enable running the unit tests in the Windows CI.