### PR TITLE
fix: Temporary workaround to parse post increments #118

### DIFF
--- a/src/parser/cxx/translation_unit.cc
+++ b/src/parser/cxx/translation_unit.cc
@@ -50,6 +50,16 @@ TranslationUnit::TranslationUnit(Control* control,
 
 TranslationUnit::~TranslationUnit() = default;
 
+auto TranslationUnit::diagnosticsClient() const -> DiagnosticsClient* {
+  return diagnosticsClient_;
+}
+
+auto TranslationUnit::changeDiagnosticsClient(
+    DiagnosticsClient* diagnosticsClient) -> DiagnosticsClient* {
+  std::swap(diagnosticsClient_, diagnosticsClient);
+  return diagnosticsClient;
+}
+
 void TranslationUnit::setSource(std::string source, std::string fileName) {
   fileName_ = std::move(fileName);
   preprocessor_->preprocess(std::move(source), fileName_, tokens_);

--- a/src/parser/cxx/translation_unit.h
+++ b/src/parser/cxx/translation_unit.h
@@ -48,9 +48,10 @@ class TranslationUnit {
 
   [[nodiscard]] auto arena() const -> Arena* { return arena_.get(); }
 
-  [[nodiscard]] auto diagnosticsClient() const -> DiagnosticsClient* {
-    return diagnosticsClient_;
-  }
+  [[nodiscard]] auto diagnosticsClient() const -> DiagnosticsClient*;
+
+  auto changeDiagnosticsClient(DiagnosticsClient* diagnosticsClient)
+      -> DiagnosticsClient*;
 
   [[nodiscard]] auto ast() const -> UnitAST* { return ast_; }
 

--- a/tests/unit_tests/parser/postfix_expr_conflicts.cc
+++ b/tests/unit_tests/parser/postfix_expr_conflicts.cc
@@ -5,10 +5,7 @@ auto decr(int x) -> int { return x--; }
 auto call(int (*f)(int, int), int x) { return (f)(x, x); }
 auto subscript(int a[], int n) -> int { return a[n]; }
 
-// expected-error@1 {{expected an expression}}
 auto incr_1(int x) -> int { return (x)++; }
-
-// expected-error@1 {{expected an expression}}
 auto decr_1(int x) -> int { return (x)--; }
 
 // expected-error@1 {{expected lambda declarator}}


### PR DESCRIPTION
This is a temporary workaround to accept a larger subset of increments expressions.