### PR TITLE
Signature of first/lastSourceLocation

### DIFF
--- a/packages/cxx-frontend/src/AST.ts
+++ b/packages/cxx-frontend/src/AST.ts
@@ -106,7 +106,7 @@ export abstract class AST {
    *
    * @returns the source location of the AST node.
    */
-  getStartLocation(): SourceLocation {
+  getStartLocation(): SourceLocation | undefined {
     return cxx.getStartLocation(this.handle, this.parser.getUnitHandle());
   }
 
@@ -115,7 +115,7 @@ export abstract class AST {
    *
    * @returns the source location of the AST node.
    */
-  getEndLocation(): SourceLocation {
+  getEndLocation(): SourceLocation | undefined {
     return cxx.getEndLocation(this.handle, this.parser.getUnitHandle());
   }
 

--- a/packages/cxx-frontend/src/cxx-js.d.ts
+++ b/packages/cxx-frontend/src/cxx-js.d.ts
@@ -98,13 +98,19 @@ export type CXX = {
   getASTSlotCount(handle: number, slot: number): number;
   getListValue(handle: number): number;
   getListNext(handle: number): number;
+  getLiteralValue(handle: number): string | undefined;
+  getIdentifierValue(handle: number): string | undefined;
   getTokenText(handle: number, unitHandle: number): string;
   getTokenKind(handle: number, unitHandle: number): TokenKind;
   getTokenLocation(handle: number, unitHandle: number): SourceLocation;
-  getStartLocation(handle: number, unitHandle: number): SourceLocation;
-  getEndLocation(handle: number, unitHandle: number): SourceLocation;
-  getLiteralValue(handle: number): string | undefined;
-  getIdentifierValue(handle: number): string | undefined;
+  getStartLocation(
+    handle: number,
+    unitHandle: number,
+  ): SourceLocation | undefined;
+  getEndLocation(
+    handle: number,
+    unitHandle: number,
+  ): SourceLocation | undefined;
 };
 
 export default function ({

--- a/packages/cxx-gen-ast/src/gen_ast_ts.ts
+++ b/packages/cxx-gen-ast/src/gen_ast_ts.ts
@@ -278,7 +278,7 @@ export abstract class AST {
      *
      * @returns the source location of the AST node.
      */
-    getStartLocation(): SourceLocation {
+    getStartLocation(): SourceLocation | undefined {
         return cxx.getStartLocation(this.handle, this.parser.getUnitHandle());
     }
 
@@ -287,7 +287,7 @@ export abstract class AST {
      *
      * @returns the source location of the AST node.
      */
-    getEndLocation(): SourceLocation {
+    getEndLocation(): SourceLocation | undefined {
         return cxx.getEndLocation(this.handle, this.parser.getUnitHandle());
     }
 

--- a/packages/cxx-storybook/src/SyntaxTree.tsx
+++ b/packages/cxx-storybook/src/SyntaxTree.tsx
@@ -155,12 +155,20 @@ export function SyntaxTree({ parser, cursorPosition }: SyntaxTreeProps) {
 }
 
 function isWithin(node: AST, line: number, column: number): boolean {
-  const { startLine, startColumn } = node.getStartLocation();
-  const { endLine, endColumn } = node.getEndLocation();
+  const start = node.getStartLocation();
+  if (!start) return false;
+
+  const end = node.getEndLocation();
+  if (!end) return false;
+
+  const { startLine, startColumn } = start;
+  const { endLine, endColumn } = end;
+
   if (line < startLine) return false;
   if (line > endLine) return false;
   if (line === startLine && column < startColumn) return false;
   if (line === endLine && column > endColumn) return false;
+
   return true;
 }
 

--- a/src/js/cxx/api.cc
+++ b/src/js/cxx/api.cc
@@ -130,13 +130,16 @@ val getTokenLocation(intptr_t handle, intptr_t unitHandle) {
 
 val getStartLocation(intptr_t handle, intptr_t unitHandle) {
   auto ast = reinterpret_cast<cxx::AST*>(handle);
-  return getTokenLocation(ast->firstSourceLocation().index(), unitHandle);
+  const auto loc = ast->firstSourceLocation();
+  if (!loc) return {};
+  return getTokenLocation(loc.index(), unitHandle);
 }
 
 val getEndLocation(intptr_t handle, intptr_t unitHandle) {
   auto ast = reinterpret_cast<cxx::AST*>(handle);
-  return getTokenLocation(ast->lastSourceLocation().previous().index(),
-                          unitHandle);
+  const auto loc = ast->lastSourceLocation().previous();
+  if (!loc) return {};
+  return getTokenLocation(loc.index(), unitHandle);
 }
 
 val getIdentifierValue(intptr_t handle) {


### PR DESCRIPTION
The source location can be undefined when an AST is incomplete
so we need to make it optional.