### PR TITLE
Set types of unresolved placeholder specifiers, underlying enums, and scoped symbols

### DIFF
--- a/src/parser/cxx/control.cc
+++ b/src/parser/cxx/control.cc
@@ -113,6 +113,7 @@ struct Control::Private {
   std::set<MemberFunctionPointerType> memberFunctionPointerTypes;
   std::set<UnresolvedNameType> unresolvedNameTypes;
   std::set<UnresolvedBoundedArrayType> unresolvedBoundedArrayTypes;
+  std::set<UnresolvedUnderlyingType> unresolvedUnderlyingTypes;
 
   std::forward_list<ClassType> classTypes;
   std::forward_list<UnionType> unionTypes;
@@ -387,6 +388,12 @@ auto Control::getUnresolvedBoundedArrayType(TranslationUnit* unit,
   return &*d->unresolvedBoundedArrayTypes
                .emplace(unit, elementType, sizeExpression)
                .first;
+}
+
+auto Control::getUnresolvedUnderlyingType(TranslationUnit* unit,
+                                          TypeIdAST* typeId)
+    -> const UnresolvedUnderlyingType* {
+  return &*d->unresolvedUnderlyingTypes.emplace(unit, typeId).first;
 }
 
 auto Control::newClassType() -> const ClassType* {

--- a/src/parser/cxx/control.cc
+++ b/src/parser/cxx/control.cc
@@ -372,9 +372,12 @@ auto Control::getMemberFunctionPointerType(const ClassType* classType,
 }
 
 auto Control::getUnresolvedNameType(TranslationUnit* unit,
-                                    NamedTypeSpecifierAST* specifier)
+                                    NestedNameSpecifierAST* nestedNameSpecifier,
+                                    UnqualifiedIdAST* unqualifiedId)
     -> const UnresolvedNameType* {
-  return &*d->unresolvedNameTypes.emplace(unit, specifier).first;
+  return &*d->unresolvedNameTypes
+               .emplace(unit, nestedNameSpecifier, unqualifiedId)
+               .first;
 }
 
 auto Control::getUnresolvedBoundedArrayType(TranslationUnit* unit,

--- a/src/parser/cxx/control.cc
+++ b/src/parser/cxx/control.cc
@@ -114,12 +114,11 @@ struct Control::Private {
   std::set<UnresolvedNameType> unresolvedNameTypes;
   std::set<UnresolvedBoundedArrayType> unresolvedBoundedArrayTypes;
   std::set<UnresolvedUnderlyingType> unresolvedUnderlyingTypes;
-
-  std::forward_list<ClassType> classTypes;
-  std::forward_list<UnionType> unionTypes;
-  std::forward_list<NamespaceType> namespaceTypes;
-  std::forward_list<EnumType> enumTypes;
-  std::forward_list<ScopedEnumType> scopedEnumTypes;
+  std::set<ClassType> classTypes;
+  std::set<UnionType> unionTypes;
+  std::set<NamespaceType> namespaceTypes;
+  std::set<EnumType> enumTypes;
+  std::set<ScopedEnumType> scopedEnumTypes;
 
   std::forward_list<NamespaceSymbol> namespaceSymbols;
   std::forward_list<ConceptSymbol> conceptSymbols;
@@ -396,31 +395,31 @@ auto Control::getUnresolvedUnderlyingType(TranslationUnit* unit,
   return &*d->unresolvedUnderlyingTypes.emplace(unit, typeId).first;
 }
 
-auto Control::newClassType() -> const ClassType* {
-  return &d->classTypes.emplace_front();
+auto Control::getClassType(ClassSymbol* symbol) -> const ClassType* {
+  return &*d->classTypes.emplace(symbol).first;
 }
 
-auto Control::newUnionType() -> const UnionType* {
-  return &d->unionTypes.emplace_front();
+auto Control::getUnionType(UnionSymbol* symbol) -> const UnionType* {
+  return &*d->unionTypes.emplace(symbol).first;
 }
 
-auto Control::newNamespaceType() -> const NamespaceType* {
-  return &d->namespaceTypes.emplace_front();
+auto Control::getNamespaceType(NamespaceSymbol* symbol)
+    -> const NamespaceType* {
+  return &*d->namespaceTypes.emplace(symbol).first;
 }
 
-auto Control::newEnumType() -> const EnumType* {
-  return &d->enumTypes.emplace_front();
+auto Control::getEnumType(EnumSymbol* symbol) -> const EnumType* {
+  return &*d->enumTypes.emplace(symbol).first;
 }
 
-auto Control::newScopedEnumType() -> const ScopedEnumType* {
-  return &d->scopedEnumTypes.emplace_front();
+auto Control::getScopedEnumType(ScopedEnumSymbol* symbol)
+    -> const ScopedEnumType* {
+  return &*d->scopedEnumTypes.emplace(symbol).first;
 }
 
 auto Control::newNamespaceSymbol(Scope* enclosingScope) -> NamespaceSymbol* {
   auto symbol = &d->namespaceSymbols.emplace_front(enclosingScope);
-  auto type = newNamespaceType();
-  symbol->setType(type);
-  type->setSymbol(symbol);
+  symbol->setType(getNamespaceType(symbol));
   return symbol;
 }
 
@@ -431,33 +430,25 @@ auto Control::newConceptSymbol(Scope* enclosingScope) -> ConceptSymbol* {
 
 auto Control::newClassSymbol(Scope* enclosingScope) -> ClassSymbol* {
   auto symbol = &d->classSymbols.emplace_front(enclosingScope);
-  auto type = newClassType();
-  symbol->setType(type);
-  type->setSymbol(symbol);
+  symbol->setType(getClassType(symbol));
   return symbol;
 }
 
 auto Control::newUnionSymbol(Scope* enclosingScope) -> UnionSymbol* {
   auto symbol = &d->unionSymbols.emplace_front(enclosingScope);
-  auto type = newUnionType();
-  symbol->setType(type);
-  type->setSymbol(symbol);
+  symbol->setType(getUnionType(symbol));
   return symbol;
 }
 
 auto Control::newEnumSymbol(Scope* enclosingScope) -> EnumSymbol* {
   auto symbol = &d->enumSymbols.emplace_front(enclosingScope);
-  auto type = newEnumType();
-  symbol->setType(type);
-  type->setSymbol(symbol);
+  symbol->setType(getEnumType(symbol));
   return symbol;
 }
 
 auto Control::newScopedEnumSymbol(Scope* enclosingScope) -> ScopedEnumSymbol* {
   auto symbol = &d->scopedEnumSymbols.emplace_front(enclosingScope);
-  auto type = newScopedEnumType();
-  symbol->setType(type);
-  type->setSymbol(symbol);
+  symbol->setType(getScopedEnumType(symbol));
   return symbol;
 }
 

--- a/src/parser/cxx/control.h
+++ b/src/parser/cxx/control.h
@@ -124,11 +124,11 @@ class Control {
   auto getUnresolvedUnderlyingType(TranslationUnit* unit, TypeIdAST* typeId)
       -> const UnresolvedUnderlyingType*;
 
-  auto newClassType() -> const ClassType*;
-  auto newUnionType() -> const UnionType*;
-  auto newNamespaceType() -> const NamespaceType*;
-  auto newEnumType() -> const EnumType*;
-  auto newScopedEnumType() -> const ScopedEnumType*;
+  auto getClassType(ClassSymbol* symbol) -> const ClassType*;
+  auto getUnionType(UnionSymbol* symbol) -> const UnionType*;
+  auto getNamespaceType(NamespaceSymbol* symbol) -> const NamespaceType*;
+  auto getEnumType(EnumSymbol* symbol) -> const EnumType*;
+  auto getScopedEnumType(ScopedEnumSymbol* symbol) -> const ScopedEnumType*;
 
   auto newNamespaceSymbol(Scope* enclosingScope) -> NamespaceSymbol*;
   auto newConceptSymbol(Scope* enclosingScope) -> ConceptSymbol*;

--- a/src/parser/cxx/control.h
+++ b/src/parser/cxx/control.h
@@ -114,7 +114,8 @@ class Control {
                                     const FunctionType* functionType)
       -> const MemberFunctionPointerType*;
   auto getUnresolvedNameType(TranslationUnit* unit,
-                             NamedTypeSpecifierAST* specifier)
+                             NestedNameSpecifierAST* nestedNameSpecifier,
+                             UnqualifiedIdAST* unqualifiedId)
       -> const UnresolvedNameType*;
   auto getUnresolvedBoundedArrayType(TranslationUnit* unit,
                                      const Type* elementType,

--- a/src/parser/cxx/control.h
+++ b/src/parser/cxx/control.h
@@ -121,6 +121,8 @@ class Control {
                                      const Type* elementType,
                                      ExpressionAST* sizeExpression)
       -> const UnresolvedBoundedArrayType*;
+  auto getUnresolvedUnderlyingType(TranslationUnit* unit, TypeIdAST* typeId)
+      -> const UnresolvedUnderlyingType*;
 
   auto newClassType() -> const ClassType*;
   auto newUnionType() -> const UnionType*;

--- a/src/parser/cxx/parser.h
+++ b/src/parser/cxx/parser.h
@@ -495,11 +495,11 @@ class Parser final {
   [[nodiscard]] auto parse_enum_key(SourceLocation& enumLoc,
                                     SourceLocation& classLoc) -> bool;
   [[nodiscard]] auto parse_enum_base(SourceLocation& colonLoc,
-                                     List<SpecifierAST*>*& typeSpecifierList)
-      -> bool;
-  void parse_enumerator_list(List<EnumeratorAST*>*& yyast);
-  void parse_enumerator_definition(EnumeratorAST*& yast);
-  void parse_enumerator(EnumeratorAST*& yyast);
+                                     List<SpecifierAST*>*& typeSpecifierList,
+                                     DeclSpecs& specs) -> bool;
+  void parse_enumerator_list(List<EnumeratorAST*>*& yyast, const Type* type);
+  void parse_enumerator_definition(EnumeratorAST*& yast, const Type* type);
+  void parse_enumerator(EnumeratorAST*& yyast, const Type* type);
   [[nodiscard]] auto parse_using_enum_declaration(DeclarationAST*& yyast)
       -> bool;
   [[nodiscard]] auto parse_namespace_definition(DeclarationAST*& yyast) -> bool;

--- a/src/parser/cxx/symbol_printer.cc
+++ b/src/parser/cxx/symbol_printer.cc
@@ -89,13 +89,27 @@ struct DumpSymbols {
   }
 
   void operator()(EnumSymbol* symbol) {
-    fmt::print(out, "{:{}}enum {}\n", "", depth * 2, to_string(symbol->name()));
+    fmt::print(out, "{:{}}enum {}", "", depth * 2, to_string(symbol->name()));
+
+    if (auto underlyingType = symbol->underlyingType()) {
+      fmt::print(out, " : {}", to_string(underlyingType));
+    }
+
+    fmt::print(out, "\n");
+
     dumpScope(symbol->scope());
   }
 
   void operator()(ScopedEnumSymbol* symbol) {
-    fmt::print(out, "{:{}}enum class {}\n", "", depth * 2,
+    fmt::print(out, "{:{}}enum class {}", "", depth * 2,
                to_string(symbol->name()));
+
+    if (auto underlyingType = symbol->underlyingType()) {
+      fmt::print(out, " : {}", to_string(underlyingType));
+    }
+
+    fmt::print(out, "\n");
+
     dumpScope(symbol->scope());
   }
 

--- a/src/parser/cxx/symbols.h
+++ b/src/parser/cxx/symbols.h
@@ -173,8 +173,17 @@ class EnumSymbol final : public Symbol {
 
   [[nodiscard]] auto scope() const -> Scope* { return scope_.get(); }
 
+  [[nodiscard]] auto underlyingType() const -> const Type* {
+    return underlyingType_;
+  }
+
+  void setUnderlyingType(const Type* underlyingType) {
+    underlyingType_ = underlyingType;
+  }
+
  private:
   std::unique_ptr<Scope> scope_;
+  const Type* underlyingType_ = nullptr;
 };
 
 class ScopedEnumSymbol final : public Symbol {
@@ -186,8 +195,17 @@ class ScopedEnumSymbol final : public Symbol {
 
   [[nodiscard]] auto scope() const -> Scope* { return scope_.get(); }
 
+  [[nodiscard]] auto underlyingType() const -> const Type* {
+    return underlyingType_;
+  }
+
+  void setUnderlyingType(const Type* underlyingType) {
+    underlyingType_ = underlyingType;
+  }
+
  private:
   std::unique_ptr<Scope> scope_;
+  const Type* underlyingType_ = nullptr;
 };
 
 class FunctionSymbol final : public Symbol {

--- a/src/parser/cxx/type_printer.cc
+++ b/src/parser/cxx/type_printer.cc
@@ -288,7 +288,13 @@ class TypePrinter {
 
   void operator()(const UnresolvedNameType* type) {
     auto unit = type->translationUnit();
-    auto [first, last] = type->specifier()->sourceLocationRange();
+    SourceLocation first;
+    if (type->nestedNameSpecifier()) {
+      first = firstSourceLocation(type->nestedNameSpecifier());
+    } else {
+      first = firstSourceLocation(type->unqualifiedId());
+    }
+    auto last = lastSourceLocation(type->unqualifiedId());
     for (auto loc = first; loc != last; loc = loc.next()) {
       const auto& tk = unit->tokenAt(loc);
       if (loc != first && (tk.leadingSpace() || tk.startOfLine()))

--- a/src/parser/cxx/type_printer.cc
+++ b/src/parser/cxx/type_printer.cc
@@ -303,16 +303,22 @@ class TypePrinter {
     }
   }
 
-  void operator()(const UnresolvedBoundedArrayType* type) {
+  auto textOf(TranslationUnit* unit, SourceLocationRange range) const
+      -> std::string {
     std::string buf;
-    buf += '[';
-    auto unit = type->translationUnit();
-    auto [first, last] = type->size()->sourceLocationRange();
+    auto [first, last] = range;
     for (auto loc = first; loc != last; loc = loc.next()) {
       const auto& tk = unit->tokenAt(loc);
       if (loc != first && (tk.leadingSpace() || tk.startOfLine())) buf += ' ';
       buf += tk.spell();
     }
+    return buf;
+  }
+
+  void operator()(const UnresolvedBoundedArrayType* type) {
+    std::string buf;
+    buf += '[';
+    buf += textOf(type->translationUnit(), type->size()->sourceLocationRange());
     buf += ']';
 
     if (ptrOps_.empty()) {
@@ -329,6 +335,13 @@ class TypePrinter {
     }
 
     accept(type->elementType());
+  }
+
+  void operator()(const UnresolvedUnderlyingType* type) {
+    specifiers_ += "__underlying_type(";
+    specifiers_ +=
+        textOf(type->translationUnit(), type->typeId()->sourceLocationRange());
+    specifiers_ += ")";
   }
 
  private:

--- a/src/parser/cxx/types.cc
+++ b/src/parser/cxx/types.cc
@@ -20,4 +20,17 @@
 
 #include <cxx/types.h>
 
-namespace cxx {}
+// cxx
+#include <cxx/symbols.h>
+
+namespace cxx {
+
+auto EnumType::underlyingType() const -> const Type* {
+  return symbol_->underlyingType();
+}
+
+auto ScopedEnumType::underlyingType() const -> const Type* {
+  return symbol_->underlyingType();
+}
+
+}  // namespace cxx

--- a/src/parser/cxx/types.cc
+++ b/src/parser/cxx/types.cc
@@ -26,11 +26,11 @@
 namespace cxx {
 
 auto EnumType::underlyingType() const -> const Type* {
-  return symbol_->underlyingType();
+  return symbol()->underlyingType();
 }
 
 auto ScopedEnumType::underlyingType() const -> const Type* {
-  return symbol_->underlyingType();
+  return symbol()->underlyingType();
 }
 
 }  // namespace cxx

--- a/src/parser/cxx/types.h
+++ b/src/parser/cxx/types.h
@@ -303,64 +303,53 @@ class FunctionType final
   [[nodiscard]] auto isNoexcept() const -> bool { return std::get<5>(*this); }
 };
 
-class ClassType final : public Type {
+class ClassType final : public Type, public std::tuple<ClassSymbol*> {
  public:
   static constexpr TypeKind Kind = TypeKind::kClass;
 
-  ClassType() : Type(Kind) {}
+  explicit ClassType(ClassSymbol* symbol) : Type(Kind), tuple(symbol) {}
 
-  [[nodiscard]] auto symbol() const -> ClassSymbol* { return symbol_; }
-
-  void setSymbol(ClassSymbol* symbol) const { symbol_ = symbol; }
-
- private:
-  mutable ClassSymbol* symbol_ = nullptr;
+  [[nodiscard]] auto symbol() const -> ClassSymbol* {
+    return std::get<0>(*this);
+  }
 };
 
-class UnionType final : public Type {
+class UnionType final : public Type, public std::tuple<UnionSymbol*> {
  public:
   static constexpr TypeKind Kind = TypeKind::kUnion;
 
-  UnionType() : Type(Kind) {}
+  explicit UnionType(UnionSymbol* symbol) : Type(Kind), tuple(symbol) {}
 
-  [[nodiscard]] auto symbol() const -> UnionSymbol* { return symbol_; }
-
-  void setSymbol(UnionSymbol* symbol) const { symbol_ = symbol; }
-
- private:
-  mutable UnionSymbol* symbol_ = nullptr;
+  [[nodiscard]] auto symbol() const -> UnionSymbol* {
+    return std::get<0>(*this);
+  }
 };
 
-class EnumType final : public Type {
+class EnumType final : public Type, public std::tuple<EnumSymbol*> {
  public:
   static constexpr TypeKind Kind = TypeKind::kEnum;
 
-  EnumType() : Type(Kind) {}
+  explicit EnumType(EnumSymbol* symbol) : Type(Kind), tuple(symbol) {}
+
+  [[nodiscard]] auto symbol() const -> EnumSymbol* {
+    return std::get<0>(*this);
+  }
 
   [[nodiscard]] auto underlyingType() const -> const Type*;
-
-  [[nodiscard]] auto symbol() const -> EnumSymbol* { return symbol_; }
-
-  void setSymbol(EnumSymbol* symbol) const { symbol_ = symbol; }
-
- private:
-  mutable EnumSymbol* symbol_ = nullptr;
 };
 
-class ScopedEnumType final : public Type {
+class ScopedEnumType final : public Type, public std::tuple<ScopedEnumSymbol*> {
  public:
   static constexpr TypeKind Kind = TypeKind::kScopedEnum;
 
-  ScopedEnumType() : Type(Kind) {}
+  explicit ScopedEnumType(ScopedEnumSymbol* symbol)
+      : Type(Kind), tuple(symbol) {}
+
+  [[nodiscard]] auto symbol() const -> ScopedEnumSymbol* {
+    return std::get<0>(*this);
+  }
 
   [[nodiscard]] auto underlyingType() const -> const Type*;
-
-  [[nodiscard]] auto symbol() const -> ScopedEnumSymbol* { return symbol_; }
-
-  void setSymbol(ScopedEnumSymbol* symbol) const { symbol_ = symbol; }
-
- private:
-  mutable ScopedEnumSymbol* symbol_ = nullptr;
 };
 
 class MemberObjectPointerType final
@@ -407,18 +396,15 @@ class ClassDescriptionType final : public Type {
   ClassDescriptionType() : Type(Kind) {}
 };
 
-class NamespaceType final : public Type {
+class NamespaceType final : public Type, public std::tuple<NamespaceSymbol*> {
  public:
   static constexpr TypeKind Kind = TypeKind::kNamespace;
 
-  NamespaceType() : Type(Kind) {}
+  explicit NamespaceType(NamespaceSymbol* symbol) : Type(Kind), tuple(symbol) {}
 
-  [[nodiscard]] auto symbol() const -> NamespaceSymbol* { return symbol_; }
-
-  void setSymbol(NamespaceSymbol* symbol) const { symbol_ = symbol; }
-
- private:
-  mutable NamespaceSymbol* symbol_ = nullptr;
+  [[nodiscard]] auto symbol() const -> NamespaceSymbol* {
+    return std::get<0>(*this);
+  }
 };
 
 class UnresolvedNameType final

--- a/src/parser/cxx/types.h
+++ b/src/parser/cxx/types.h
@@ -337,6 +337,8 @@ class EnumType final : public Type {
 
   EnumType() : Type(Kind) {}
 
+  [[nodiscard]] auto underlyingType() const -> const Type*;
+
   [[nodiscard]] auto symbol() const -> EnumSymbol* { return symbol_; }
 
   void setSymbol(EnumSymbol* symbol) const { symbol_ = symbol; }
@@ -350,6 +352,8 @@ class ScopedEnumType final : public Type {
   static constexpr TypeKind Kind = TypeKind::kScopedEnum;
 
   ScopedEnumType() : Type(Kind) {}
+
+  [[nodiscard]] auto underlyingType() const -> const Type*;
 
   [[nodiscard]] auto symbol() const -> ScopedEnumSymbol* { return symbol_; }
 
@@ -463,6 +467,22 @@ class UnresolvedBoundedArrayType final
   [[nodiscard]] auto size() const -> ExpressionAST* {
     return std::get<2>(*this);
   }
+};
+
+class UnresolvedUnderlyingType final
+    : public Type,
+      public std::tuple<TranslationUnit*, TypeIdAST*> {
+ public:
+  static constexpr TypeKind Kind = TypeKind::kUnresolvedUnderlying;
+
+  UnresolvedUnderlyingType(TranslationUnit* unit, TypeIdAST* typeId)
+      : Type(Kind), tuple(unit, typeId) {}
+
+  [[nodiscard]] auto translationUnit() const -> TranslationUnit* {
+    return std::get<0>(*this);
+  }
+
+  [[nodiscard]] auto typeId() const -> TypeIdAST* { return std::get<1>(*this); }
 };
 
 template <typename Visitor>

--- a/src/parser/cxx/types.h
+++ b/src/parser/cxx/types.h
@@ -419,20 +419,26 @@ class NamespaceType final : public Type {
 
 class UnresolvedNameType final
     : public Type,
-      public std::tuple<TranslationUnit*, NamedTypeSpecifierAST*> {
+      public std::tuple<TranslationUnit*, NestedNameSpecifierAST*,
+                        UnqualifiedIdAST*> {
  public:
   static constexpr TypeKind Kind = TypeKind::kUnresolvedName;
 
   UnresolvedNameType(TranslationUnit* unit,
-                     NamedTypeSpecifierAST* namedTypeSpecifier)
-      : Type(Kind), tuple(unit, namedTypeSpecifier) {}
+                     NestedNameSpecifierAST* nestedNameSpecifier,
+                     UnqualifiedIdAST* unqualifiedId)
+      : Type(Kind), tuple(unit, nestedNameSpecifier, unqualifiedId) {}
 
   [[nodiscard]] auto translationUnit() const -> TranslationUnit* {
     return std::get<0>(*this);
   }
 
-  [[nodiscard]] auto specifier() const -> NamedTypeSpecifierAST* {
+  [[nodiscard]] auto nestedNameSpecifier() const -> NestedNameSpecifierAST* {
     return std::get<1>(*this);
+  }
+
+  [[nodiscard]] auto unqualifiedId() const -> UnqualifiedIdAST* {
+    return std::get<2>(*this);
   }
 };
 

--- a/src/parser/cxx/types_fwd.h
+++ b/src/parser/cxx/types_fwd.h
@@ -64,7 +64,8 @@ namespace cxx {
   V(ClassDescription)             \
   V(Namespace)                    \
   V(UnresolvedName)               \
-  V(UnresolvedBoundedArray)
+  V(UnresolvedBoundedArray)       \
+  V(UnresolvedUnderlying)
 
 class Type;
 


### PR DESCRIPTION
This pull request includes changes to set the types of unresolved placeholder specifiers, underlying enums, and scoped symbols.
The changes include fixing the types of scoped symbols, setting the type of the unresolved bounded array, and adding support for the underlying type of enums. 