### PR TITLE
Add type checker option to CLI

### DIFF
--- a/src/frontend/cxx/cli.cc
+++ b/src/frontend/cxx/cli.cc
@@ -142,6 +142,8 @@ std::vector<CLIOptionDescr> options{
     {"-x", "Specify the language from the compiler driver",
      CLIOptionDescrKind::kSeparated},
 
+    {"-fcheck", "Enable type checker (WIP)", &CLI::opt_fcheck},
+
     {"-fsyntax-only", "Check only the syntax", &CLI::opt_fsyntax_only},
 
     {"-fstatic-assert", "Enable static asserts", &CLI::opt_fstatic_assert,

--- a/src/frontend/cxx/cli.h
+++ b/src/frontend/cxx/cli.h
@@ -67,6 +67,7 @@ class CLI {
   bool opt_c = false;
   bool opt_fsyntax_only = false;
   bool opt_fstatic_assert = false;
+  bool opt_fcheck = false;
   bool opt_verify = false;
   bool opt_v = false;
   bool opt_emit_ast = false;

--- a/src/frontend/cxx/frontend.cc
+++ b/src/frontend/cxx/frontend.cc
@@ -247,6 +247,7 @@ auto runOnFile(const CLI& cli, const std::string& fileName) -> bool {
     preprocesor->squeeze();
 
     unit.parse(ParserConfiguration{
+        .checkTypes = cli.opt_fcheck,
         .fuzzyTemplateResolution = true,
         .staticAssert = cli.opt_fstatic_assert,
     });

--- a/src/parser/cxx/const_value.h
+++ b/src/parser/cxx/const_value.h
@@ -32,4 +32,15 @@ using ConstValue =
     std::variant<bool, std::int32_t, std::uint32_t, std::int64_t, std::uint64_t,
                  float, double, const StringLiteral*>;
 
+template <typename T>
+struct ArthmeticConversion {
+  auto operator()(const StringLiteral* value) const -> ConstValue {
+    return ConstValue(value);
+  }
+
+  auto operator()(auto value) const -> ConstValue {
+    return ConstValue(static_cast<T>(value));
+  }
+};
+
 }  // namespace cxx

--- a/src/parser/cxx/parser.h
+++ b/src/parser/cxx/parser.h
@@ -702,6 +702,13 @@ class Parser final {
 
   void check_type_traits();
 
+  // standard conversions
+  auto lvalue_to_rvalue_conversion(ExpressionAST*& expr) -> bool;
+  auto array_to_pointer_conversion(ExpressionAST*& expr) -> bool;
+  auto function_to_pointer_conversion(ExpressionAST*& expr) -> bool;
+  auto integral_promotion(ExpressionAST*& expr) -> bool;
+  auto floating_point_promotion(ExpressionAST*& expr) -> bool;
+
   auto is_prvalue(ExpressionAST* expr) const -> bool;
   auto is_lvalue(ExpressionAST* expr) const -> bool;
   auto is_xvalue(ExpressionAST* expr) const -> bool;

--- a/src/parser/cxx/parser_fwd.h
+++ b/src/parser/cxx/parser_fwd.h
@@ -26,6 +26,7 @@ namespace cxx {
 class Parser;
 
 struct ParserConfiguration {
+  bool checkTypes = false;
   bool fuzzyTemplateResolution = false;
   bool staticAssert = false;
 };

--- a/src/parser/cxx/symbols.h
+++ b/src/parser/cxx/symbols.h
@@ -160,8 +160,22 @@ class UnionSymbol final : public Symbol {
 
   [[nodiscard]] auto scope() const -> Scope* { return scope_.get(); }
 
+  [[nodiscard]] auto templateParameters() const
+      -> const TemplateParametersSymbol* {
+    return templateParameters_;
+  }
+
+  void setTemplateParameters(TemplateParametersSymbol* templateParameters) {
+    templateParameters_ = templateParameters;
+  }
+
+  [[nodiscard]] auto isComplete() const -> bool { return isComplete_; }
+  void setComplete(bool isComplete) { isComplete_ = isComplete; }
+
  private:
   std::unique_ptr<Scope> scope_;
+  TemplateParametersSymbol* templateParameters_ = nullptr;
+  bool isComplete_ = false;
 };
 
 class EnumSymbol final : public Symbol {

--- a/src/parser/cxx/types.cc
+++ b/src/parser/cxx/types.cc
@@ -33,4 +33,8 @@ auto ScopedEnumType::underlyingType() const -> const Type* {
   return symbol()->underlyingType();
 }
 
+auto ClassType::isComplete() const -> bool { return symbol()->isComplete(); }
+
+auto UnionType::isComplete() const -> bool { return symbol()->isComplete(); }
+
 }  // namespace cxx

--- a/src/parser/cxx/types.h
+++ b/src/parser/cxx/types.h
@@ -312,6 +312,8 @@ class ClassType final : public Type, public std::tuple<ClassSymbol*> {
   [[nodiscard]] auto symbol() const -> ClassSymbol* {
     return std::get<0>(*this);
   }
+
+  [[nodiscard]] auto isComplete() const -> bool;
 };
 
 class UnionType final : public Type, public std::tuple<UnionSymbol*> {
@@ -323,6 +325,8 @@ class UnionType final : public Type, public std::tuple<UnionSymbol*> {
   [[nodiscard]] auto symbol() const -> UnionSymbol* {
     return std::get<0>(*this);
   }
+
+  [[nodiscard]] auto isComplete() const -> bool;
 };
 
 class EnumType final : public Type, public std::tuple<EnumSymbol*> {


### PR DESCRIPTION
This pull request adds a new option `-fcheck` to the CLI, which enables the type checker. This is a work in progress feature and is disabled by default. Additionally, the pull request includes some initial work to support standard conversions.