### PR TITLE
Add OverloadSet symbol and sketch naive unqualified lookup

### DIFF
--- a/src/frontend/cxx/frontend.cc
+++ b/src/frontend/cxx/frontend.cc
@@ -257,7 +257,7 @@ auto runOnFile(const CLI& cli, const std::string& fileName) -> bool {
     unit.parse(ParserConfiguration{
         .checkTypes = cli.opt_fcheck,
         .fuzzyTemplateResolution = true,
-        .staticAssert = cli.opt_fstatic_assert,
+        .staticAssert = cli.opt_fstatic_assert || cli.opt_fcheck,
     });
 
     if (cli.opt_dump_symbols && unit.globalScope()) {

--- a/src/parser/cxx/ast.h
+++ b/src/parser/cxx/ast.h
@@ -162,6 +162,7 @@ class MemInitializerAST : public AST {
 class NestedNameSpecifierAST : public AST {
  public:
   using AST::AST;
+  Symbol* symbol = nullptr;
 };
 
 class NewInitializerAST : public AST {
@@ -1249,6 +1250,7 @@ class IdExpressionAST final : public ExpressionAST {
   NestedNameSpecifierAST* nestedNameSpecifier = nullptr;
   SourceLocation templateLoc;
   UnqualifiedIdAST* unqualifiedId = nullptr;
+  Symbol* symbol = nullptr;
   bool isTemplateIntroduced = false;
 
   void accept(ASTVisitor* visitor) override { visitor->visit(this); }

--- a/src/parser/cxx/ast_cloner.cc
+++ b/src/parser/cxx/ast_cloner.cc
@@ -1157,6 +1157,8 @@ void ASTCloner::visit(IdExpressionAST* ast) {
 
   copy->unqualifiedId = accept(ast->unqualifiedId);
 
+  copy->symbol = ast->symbol;
+
   copy->isTemplateIntroduced = ast->isTemplateIntroduced;
 }
 
@@ -2819,12 +2821,16 @@ void ASTCloner::visit(GlobalNestedNameSpecifierAST* ast) {
   auto copy = new (arena_) GlobalNestedNameSpecifierAST();
   copy_ = copy;
 
+  copy->symbol = ast->symbol;
+
   copy->scopeLoc = ast->scopeLoc;
 }
 
 void ASTCloner::visit(SimpleNestedNameSpecifierAST* ast) {
   auto copy = new (arena_) SimpleNestedNameSpecifierAST();
   copy_ = copy;
+
+  copy->symbol = ast->symbol;
 
   copy->nestedNameSpecifier = accept(ast->nestedNameSpecifier);
 
@@ -2839,6 +2845,8 @@ void ASTCloner::visit(DecltypeNestedNameSpecifierAST* ast) {
   auto copy = new (arena_) DecltypeNestedNameSpecifierAST();
   copy_ = copy;
 
+  copy->symbol = ast->symbol;
+
   copy->nestedNameSpecifier = accept(ast->nestedNameSpecifier);
 
   copy->decltypeSpecifier = accept(ast->decltypeSpecifier);
@@ -2849,6 +2857,8 @@ void ASTCloner::visit(DecltypeNestedNameSpecifierAST* ast) {
 void ASTCloner::visit(TemplateNestedNameSpecifierAST* ast) {
   auto copy = new (arena_) TemplateNestedNameSpecifierAST();
   copy_ = copy;
+
+  copy->symbol = ast->symbol;
 
   copy->nestedNameSpecifier = accept(ast->nestedNameSpecifier);
 

--- a/src/parser/cxx/control.cc
+++ b/src/parser/cxx/control.cc
@@ -113,6 +113,7 @@ struct Control::Private {
   std::set<PointerType> pointerTypes;
   std::set<LvalueReferenceType> lvalueReferenceTypes;
   std::set<RvalueReferenceType> rvalueReferenceTypes;
+  std::set<OverloadSetType> overloadSetTypes;
   std::set<FunctionType> functionTypes;
   std::set<MemberObjectPointerType> memberObjectPointerTypes;
   std::set<MemberFunctionPointerType> memberFunctionPointerTypes;
@@ -131,6 +132,7 @@ struct Control::Private {
   std::forward_list<UnionSymbol> unionSymbols;
   std::forward_list<EnumSymbol> enumSymbols;
   std::forward_list<ScopedEnumSymbol> scopedEnumSymbols;
+  std::forward_list<OverloadSetSymbol> overloadSetSymbols;
   std::forward_list<FunctionSymbol> functionSymbols;
   std::forward_list<LambdaSymbol> lambdaSymbols;
   std::forward_list<FunctionParametersSymbol> functionParametersSymbol;
@@ -355,6 +357,11 @@ auto Control::getRvalueReferenceType(const Type* elementType)
   return &*d->rvalueReferenceTypes.emplace(elementType).first;
 }
 
+auto Control::getOverloadSetType(OverloadSetSymbol* symbol)
+    -> const OverloadSetType* {
+  return &*d->overloadSetTypes.emplace(symbol).first;
+}
+
 auto Control::getFunctionType(const Type* returnType,
                               std::vector<const Type*> parameterTypes,
                               bool isVariadic, CvQualifiers cvQualifiers,
@@ -456,6 +463,12 @@ auto Control::newEnumSymbol(Scope* enclosingScope) -> EnumSymbol* {
 auto Control::newScopedEnumSymbol(Scope* enclosingScope) -> ScopedEnumSymbol* {
   auto symbol = &d->scopedEnumSymbols.emplace_front(enclosingScope);
   symbol->setType(getScopedEnumType(symbol));
+  return symbol;
+}
+
+auto Control::newOverloadSetSymbol(Scope* enclosingScope)
+    -> OverloadSetSymbol* {
+  auto symbol = &d->overloadSetSymbols.emplace_front(enclosingScope);
   return symbol;
 }
 

--- a/src/parser/cxx/control.cc
+++ b/src/parser/cxx/control.cc
@@ -469,6 +469,7 @@ auto Control::newScopedEnumSymbol(Scope* enclosingScope) -> ScopedEnumSymbol* {
 auto Control::newOverloadSetSymbol(Scope* enclosingScope)
     -> OverloadSetSymbol* {
   auto symbol = &d->overloadSetSymbols.emplace_front(enclosingScope);
+  symbol->setType(getOverloadSetType(symbol));
   return symbol;
 }
 

--- a/src/parser/cxx/control.h
+++ b/src/parser/cxx/control.h
@@ -101,6 +101,7 @@ class Control {
       -> const LvalueReferenceType*;
   auto getRvalueReferenceType(const Type* elementType)
       -> const RvalueReferenceType*;
+  auto getOverloadSetType(OverloadSetSymbol* symbol) -> const OverloadSetType*;
   auto getFunctionType(const Type* returnType,
                        std::vector<const Type*> parameterTypes,
                        bool isVariadic = false,
@@ -136,6 +137,7 @@ class Control {
   auto newUnionSymbol(Scope* enclosingScope) -> UnionSymbol*;
   auto newEnumSymbol(Scope* enclosingScope) -> EnumSymbol*;
   auto newScopedEnumSymbol(Scope* enclosingScope) -> ScopedEnumSymbol*;
+  auto newOverloadSetSymbol(Scope* enclosingScope) -> OverloadSetSymbol*;
   auto newFunctionSymbol(Scope* enclosingScope) -> FunctionSymbol*;
   auto newLambdaSymbol(Scope* enclosingScope) -> LambdaSymbol*;
   auto newFunctionParametersSymbol(Scope* enclosingScope)

--- a/src/parser/cxx/parser.h
+++ b/src/parser/cxx/parser.h
@@ -94,6 +94,8 @@ class Parser final {
   struct LoopParser;
   struct ClassHead;
   struct GetDeclaratorType;
+  struct UnqualifiedLookup;
+  struct DeclareSymbol;
 
   enum struct BindingContext {
     kNamespace,
@@ -170,8 +172,16 @@ class Parser final {
   [[nodiscard]] auto parse_primary_expression(ExpressionAST*& yyast,
                                               bool inRequiresClause = false)
       -> bool;
+
+  enum struct IdExpressionContext {
+    kExpression,
+    kMember,
+    kTemplateParameter,
+    kRequiresClause,
+  };
+
   [[nodiscard]] auto parse_id_expression(IdExpressionAST*& yyast,
-                                         bool inRequiresClause = false) -> bool;
+                                         IdExpressionContext ctx) -> bool;
   [[nodiscard]] auto parse_maybe_template_id(UnqualifiedIdAST*& yyast,
                                              bool isTemplateIntroduced,
                                              bool inRequiresClause) -> bool;
@@ -505,7 +515,6 @@ class Parser final {
                                      List<SpecifierAST*>*& typeSpecifierList,
                                      DeclSpecs& specs) -> bool;
   void parse_enumerator_list(List<EnumeratorAST*>*& yyast, const Type* type);
-  void parse_enumerator_definition(EnumeratorAST*& yast, const Type* type);
   void parse_enumerator(EnumeratorAST*& yyast, const Type* type);
   [[nodiscard]] auto parse_using_enum_declaration(DeclarationAST*& yyast)
       -> bool;

--- a/src/parser/cxx/scope.cc
+++ b/src/parser/cxx/scope.cc
@@ -100,4 +100,14 @@ void Scope::addSymbol(Symbol* symbol) {
   symbols_.emplace(symbol->name(), symbol);
 }
 
+void Scope::removeSymbol(Symbol* symbol) {
+  auto [first, last] = symbols_.equal_range(symbol->name());
+  for (auto it = first; it != last; ++it) {
+    if (it->second == symbol) {
+      symbols_.erase(it);
+      break;
+    }
+  }
+}
+
 }  // namespace cxx

--- a/src/parser/cxx/scope.h
+++ b/src/parser/cxx/scope.h
@@ -54,6 +54,7 @@ class Scope {
   }
 
   void addSymbol(Symbol* symbol);
+  void removeSymbol(Symbol* symbol);
 
  private:
   Scope* parent_ = nullptr;

--- a/src/parser/cxx/symbol_printer.cc
+++ b/src/parser/cxx/symbol_printer.cc
@@ -115,6 +115,11 @@ struct DumpSymbols {
     dumpScope(symbol->scope());
   }
 
+  void operator()(OverloadSetSymbol* symbol) {
+    indent();
+    fmt::print(out, "overload set {}\n", to_string(symbol->name()));
+  }
+
   void operator()(FunctionSymbol* symbol) {
     indent();
 

--- a/src/parser/cxx/symbols.cc
+++ b/src/parser/cxx/symbols.cc
@@ -73,6 +73,11 @@ FunctionSymbol::FunctionSymbol(Scope* enclosingScope)
 
 FunctionSymbol::~FunctionSymbol() {}
 
+OverloadSetSymbol::OverloadSetSymbol(Scope* enclosingScope)
+    : Symbol(Kind, enclosingScope) {}
+
+OverloadSetSymbol::~OverloadSetSymbol() {}
+
 LambdaSymbol::LambdaSymbol(Scope* enclosingScope)
     : Symbol(Kind, enclosingScope) {
   scope_ = std::make_unique<Scope>(enclosingScope);

--- a/src/parser/cxx/symbols.h
+++ b/src/parser/cxx/symbols.h
@@ -285,6 +285,27 @@ class FunctionSymbol final : public Symbol {
   bool isDefaulted_ = false;
 };
 
+class OverloadSetSymbol final : public Symbol {
+ public:
+  constexpr static auto Kind = SymbolKind::kOverloadSet;
+
+  explicit OverloadSetSymbol(Scope* enclosingScope);
+  ~OverloadSetSymbol() override;
+
+  [[nodiscard]] auto functions() const -> const std::vector<FunctionSymbol*>& {
+    return functions_;
+  }
+
+  void setFunctions(std::vector<FunctionSymbol*> functions) {
+    functions_ = std::move(functions);
+  }
+
+  void addFunction(FunctionSymbol* function) { functions_.push_back(function); }
+
+ private:
+  std::vector<FunctionSymbol*> functions_;
+};
+
 class LambdaSymbol final : public Symbol {
  public:
   constexpr static auto Kind = SymbolKind::kLambda;

--- a/src/parser/cxx/symbols.h
+++ b/src/parser/cxx/symbols.h
@@ -20,11 +20,13 @@
 
 #pragma once
 
+#include <cxx/const_value.h>
 #include <cxx/names_fwd.h>
 #include <cxx/symbols_fwd.h>
 #include <cxx/types_fwd.h>
 
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -604,6 +606,15 @@ class EnumeratorSymbol final : public Symbol {
 
   explicit EnumeratorSymbol(Scope* enclosingScope);
   ~EnumeratorSymbol() override;
+
+  [[nodiscard]] auto value() const -> const std::optional<ConstValue>& {
+    return value_;
+  }
+
+  void setValue(const std::optional<ConstValue>& value) { value_ = value; }
+
+ private:
+  std::optional<ConstValue> value_;
 };
 
 template <typename Visitor>

--- a/src/parser/cxx/symbols_fwd.h
+++ b/src/parser/cxx/symbols_fwd.h
@@ -44,7 +44,8 @@ namespace cxx {
   V(TypeParameter)             \
   V(NonTypeParameter)          \
   V(TemplateTypeParameter)     \
-  V(ConstraintTypeParameter)
+  V(ConstraintTypeParameter)   \
+  V(OverloadSet)
 
 class Symbol;
 class Scope;

--- a/src/parser/cxx/type_printer.cc
+++ b/src/parser/cxx/type_printer.cc
@@ -225,6 +225,10 @@ class TypePrinter {
     accept(type->elementType());
   }
 
+  void operator()(const OverloadSetType* type) {
+    specifiers_.append("$overload-set");
+  }
+
   void operator()(const FunctionType* type) {
     std::string signature;
 

--- a/src/parser/cxx/type_traits.h
+++ b/src/parser/cxx/type_traits.h
@@ -593,6 +593,10 @@ class TypeTraits {
       return control()->getLvalueReferenceType(type);
     }
 
+    auto operator()(const LvalueReferenceType* type) const -> const Type* {
+      return type;
+    }
+
     auto operator()(const RvalueReferenceType* type) const -> const Type* {
       return control()->getLvalueReferenceType(type->elementType());
     }

--- a/src/parser/cxx/type_traits.h
+++ b/src/parser/cxx/type_traits.h
@@ -981,6 +981,11 @@ class TypeTraits {
       return type == otherType;
     }
 
+    auto operator()(const OverloadSetType* type,
+                    const OverloadSetType* otherType) const -> bool {
+      return type->symbol() == otherType->symbol();
+    }
+
   } is_same_{*this};
 };
 

--- a/src/parser/cxx/types.h
+++ b/src/parser/cxx/types.h
@@ -268,6 +268,19 @@ class RvalueReferenceType final : public Type, public std::tuple<const Type*> {
   }
 };
 
+class OverloadSetType final : public Type,
+                              public std::tuple<OverloadSetSymbol*> {
+ public:
+  static constexpr TypeKind Kind = TypeKind::kOverloadSet;
+
+  explicit OverloadSetType(OverloadSetSymbol* symbol)
+      : Type(Kind), tuple(symbol) {}
+
+  [[nodiscard]] auto symbol() const -> OverloadSetSymbol* {
+    return std::get<0>(*this);
+  }
+};
+
 class FunctionType final
     : public Type,
       public std::tuple<const Type*, std::vector<const Type*>, bool,

--- a/src/parser/cxx/types_fwd.h
+++ b/src/parser/cxx/types_fwd.h
@@ -65,7 +65,8 @@ namespace cxx {
   V(Namespace)                    \
   V(UnresolvedName)               \
   V(UnresolvedBoundedArray)       \
-  V(UnresolvedUnderlying)
+  V(UnresolvedUnderlying)         \
+  V(OverloadSet)
 
 class Type;
 

--- a/tests/unit_tests/sema/decltype_01.cc
+++ b/tests/unit_tests/sema/decltype_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fstatic-assert %s
+// RUN: %cxx -verify -fcheck %s
 
 static_assert(__is_null_pointer(decltype(nullptr)));
 

--- a/tests/unit_tests/sema/static_assert_01.cc
+++ b/tests/unit_tests/sema/static_assert_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fstatic-assert %s
+// RUN: %cxx -verify -fcheck %s
 
 static_assert(true);
 static_assert('a');

--- a/tests/unit_tests/sema/type_traits_01.cc
+++ b/tests/unit_tests/sema/type_traits_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fstatic-assert %s
+// RUN: %cxx -verify -fcheck %s
 
 //
 // is_void trait
@@ -261,3 +261,32 @@ static_assert(__is_reference(const int&&));
 
 // expected-error@1 {{static assert failed}}
 static_assert(__is_reference(int));
+
+int var;
+static_assert(__is_integral(decltype(var)));
+static_assert(__is_lvalue_reference(decltype((var))));
+static_assert(__is_same(decltype(var), int));
+static_assert(__is_same(decltype((var)), int&));
+
+int array[10];
+static_assert(__is_same(decltype(array), int[10]));
+static_assert(__is_same(decltype((array)), int (&)[10]));
+static_assert(__is_array(decltype(array)));
+static_assert(__is_bounded_array(decltype(array)));
+
+int func(int);
+static_assert(__is_same(decltype(func), int(int)));
+static_assert(__is_function(decltype(func)));
+
+const int ci = 0;
+static_assert(__is_same(decltype(ci), const int));
+static_assert(__is_const(decltype(ci)));
+
+const int& cri = ci;
+static_assert(__is_same(decltype(cri), const int&));
+static_assert(__is_same(decltype((cri)), const int&));
+
+int&& rrv = static_cast<int&&>(var);
+static_assert(__is_same(decltype(rrv), int&&));
+static_assert(__is_rvalue_reference(decltype(rrv)));
+static_assert(__is_same(decltype((rrv)), int&));


### PR DESCRIPTION
This pull request adds the `OverloadSetSymbol` class and the `OverloadSetType` type, which represent a set of overloaded functions. It also sketches a naive implementation of unqualified lookup, which searches for a symbol in the current scope and its parent scopes.