### PR TITLE
fix: Add internal stdarg.h header file

### DIFF
--- a/src/lib/cxx/include/stdarg.h
+++ b/src/lib/cxx/include/stdarg.h
@@ -1,4 +1,15 @@
 #pragma once
 
-typedef __builtin_va_list va_list;
+#ifndef __GNUC_VA_LIST
+#define __GNUC_VA_LIST 1
 typedef __builtin_va_list __gnuc_va_list;
+#endif
+
+typedef __builtin_va_list va_list;
+
+#define va_start(ap, param) __builtin_va_start(ap, param)
+#define va_end(ap) __builtin_va_end(ap)
+#define va_arg(ap, type) __builtin_va_arg(ap, type)
+
+#define __va_copy(d, s) __builtin_va_copy(d, s)
+#define va_copy(dest, src) __builtin_va_copy(dest, src)


### PR DESCRIPTION
Add macros to access the va builtin intrinsics (#280)