### PR TITLE
fix: Reject lambda expressions that don't have a body

### DIFF
--- a/src/parser/cxx/parser.cc
+++ b/src/parser/cxx/parser.cc
@@ -1534,7 +1534,6 @@ auto Parser::parse_lambda_expression(ExpressionAST*& yyast) -> bool {
   ScopeGuard scopeGuard{this};
 
   auto symbol = control_->newLambdaSymbol(scope_);
-  std::invoke(DeclareSymbol{this, scope_}, symbol);
 
   scope_ = symbol->scope();
 
@@ -1596,6 +1595,10 @@ auto Parser::parse_lambda_expression(ExpressionAST*& yyast) -> bool {
   } else {
     scope_ = symbol->scope();
   }
+
+  if (!lookat(TokenKind::T_LBRACE)) return false;
+
+  std::invoke(DeclareSymbol{this, scope_}, symbol);
 
   if (!parse_compound_statement(ast->statement)) {
     parse_error("expected a compound statement");

--- a/tests/unit_tests/parser/postfix_expr_conflicts.cc
+++ b/tests/unit_tests/parser/postfix_expr_conflicts.cc
@@ -8,5 +8,4 @@ auto subscript(int a[], int n) -> int { return a[n]; }
 auto incr_1(int x) -> int { return (x)++; }
 auto decr_1(int x) -> int { return (x)--; }
 
-// expected-error@1 {{expected a compound statement}}
 auto subscript_1(int a[], int n) -> int { return (a)[n]; }


### PR DESCRIPTION
This change will fix a possible conflict between lambda expresssions
and subscripts. (#290)