### PR TITLE
fix: Set begining-of-line flag of tokens that follow comments

### DIFF
--- a/src/parser/cxx/lexer.cc
+++ b/src/parser/cxx/lexer.cc
@@ -22,7 +22,6 @@
 #include <cxx/private/format.h>
 #include <utf8/unchecked.h>
 
-#include <cassert>
 #include <cctype>
 #include <unordered_map>
 
@@ -522,6 +521,7 @@ auto Lexer::readToken() -> TokenKind {
           consume();
         }
         leadingSpace_ = tokenLeadingSpace_;
+        startOfLine_ = tokenStartOfLine_;
         return TokenKind::T_COMMENT;
       }
       if (pos_ != end_ && LA() == '=') {

--- a/tests/unit_tests/preprocessor/bol_001.cc
+++ b/tests/unit_tests/preprocessor/bol_001.cc
@@ -1,0 +1,13 @@
+// RUN: %cxx -verify -E %s -o - | %filecheck %s
+
+// clang-format off
+aa
+#if 0
+unreachable
+#endif
+/**/bb
+cc
+
+// CHECK: {{^}}aa{{$}}
+// CHECK: {{^}}bb{{$}}
+// CHECK: {{^}}cc{{$}}


### PR DESCRIPTION
Closes #298
