### PR TITLE
chore: Skip the gcc nullable annotations also when using the linux toolchain

### DIFF
--- a/src/parser/cxx/gcc_linux_toolchain.cc
+++ b/src/parser/cxx/gcc_linux_toolchain.cc
@@ -70,6 +70,8 @@ void GCCLinuxToolchain::addPredefinedMacros() {
   defineMacro("__extension__", "");
   defineMacro("__null", "nullptr");
   defineMacro("__signed__", "signed");
+  defineMacro("_Nullable", "");
+  defineMacro("_Nonnull", "");
   defineMacro("_Pragma(x)", "");
 
   if (arch_ == "aarch64") {

--- a/src/parser/cxx/wasm32_wasi_toolchain.cc
+++ b/src/parser/cxx/wasm32_wasi_toolchain.cc
@@ -76,6 +76,8 @@ void Wasm32WasiToolchain::addPredefinedMacros() {
   defineMacro("__strong", "");
   defineMacro("__autoreleasing", "");
   defineMacro("__unsafe_unretained", "");
+  defineMacro("_Nullable", "");
+  defineMacro("_Nonnull", "");
 
   defineMacro("_GNU_SOURCE", "1");
   defineMacro("_ILP32", "1");


### PR DESCRIPTION
Closes #305
