### PR TITLE
Update CI workflow to macOS 14 and libfmt to 10.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,14 +107,10 @@ jobs:
           retention-days: 1
 
   build-macos:
-    runs-on: macos-13
+    runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v3
-
-      - name: Set up Xcode 15
-        run: |
-          sudo xcode-select --switch /Applications/Xcode_15.0.app
 
       - name: Install unit tests requirements
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ endif()
 FetchContent_Declare(
     fmt
     GIT_REPOSITORY  https://github.com/fmtlib/fmt
-    GIT_TAG         10.2.0
+    GIT_TAG         10.2.1
     GIT_SHALLOW     1
 )
 

--- a/src/parser/cxx/control.cc
+++ b/src/parser/cxx/control.cc
@@ -117,6 +117,7 @@ struct Control::Private {
   std::set<MemberObjectPointerType> memberObjectPointerTypes;
   std::set<MemberFunctionPointerType> memberFunctionPointerTypes;
   std::set<TypeParameterType> typeParameterTypes;
+  std::set<TemplateTypeParameterType> templateTypeParameterTypes;
   std::set<UnresolvedNameType> unresolvedNameTypes;
   std::set<UnresolvedBoundedArrayType> unresolvedBoundedArrayTypes;
   std::set<UnresolvedUnderlyingType> unresolvedUnderlyingTypes;
@@ -394,6 +395,11 @@ auto Control::getTypeParameterType(TypeParameterSymbol* symbol)
   return &*d->typeParameterTypes.emplace(symbol).first;
 }
 
+auto Control::getTemplateTypeParameterType(TemplateTypeParameterSymbol* symbol)
+    -> const TemplateTypeParameterType* {
+  return &*d->templateTypeParameterTypes.emplace(symbol).first;
+}
+
 auto Control::getUnresolvedNameType(TranslationUnit* unit,
                                     NestedNameSpecifierAST* nestedNameSpecifier,
                                     UnqualifiedIdAST* unqualifiedId)
@@ -531,15 +537,16 @@ auto Control::newTypeParameterSymbol(Scope* enclosingScope)
   return symbol;
 }
 
-auto Control::newNonTypeParameterSymbol(Scope* enclosingScope)
-    -> NonTypeParameterSymbol* {
-  auto symbol = &d->nonTypeParameterSymbols.emplace_front(enclosingScope);
-  return symbol;
-}
-
 auto Control::newTemplateTypeParameterSymbol(Scope* enclosingScope)
     -> TemplateTypeParameterSymbol* {
   auto symbol = &d->templateTypeParameterSymbols.emplace_front(enclosingScope);
+  symbol->setType(getTemplateTypeParameterType(symbol));
+  return symbol;
+}
+
+auto Control::newNonTypeParameterSymbol(Scope* enclosingScope)
+    -> NonTypeParameterSymbol* {
+  auto symbol = &d->nonTypeParameterSymbols.emplace_front(enclosingScope);
   return symbol;
 }
 

--- a/src/parser/cxx/control.h
+++ b/src/parser/cxx/control.h
@@ -118,6 +118,8 @@ class Control {
       -> const MemberFunctionPointerType*;
   auto getTypeParameterType(TypeParameterSymbol* symbol)
       -> const TypeParameterType*;
+  auto getTemplateTypeParameterType(TemplateTypeParameterSymbol* symbol)
+      -> const TemplateTypeParameterType*;
   auto getUnresolvedNameType(TranslationUnit* unit,
                              NestedNameSpecifierAST* nestedNameSpecifier,
                              UnqualifiedIdAST* unqualifiedId)

--- a/src/parser/cxx/memory_layout.cc
+++ b/src/parser/cxx/memory_layout.cc
@@ -208,6 +208,11 @@ struct SizeOf {
     return std::nullopt;
   }
 
+  auto operator()(const TemplateTypeParameterType* type) const
+      -> std::optional<std::size_t> {
+    return std::nullopt;
+  }
+
   auto operator()(const UnresolvedNameType* type) const
       -> std::optional<std::size_t> {
     return std::nullopt;

--- a/src/parser/cxx/type_printer.cc
+++ b/src/parser/cxx/type_printer.cc
@@ -315,6 +315,10 @@ class TypePrinter {
     specifiers_.append(to_string(type->symbol()->name()));
   }
 
+  void operator()(const TemplateTypeParameterType* type) {
+    specifiers_.append(to_string(type->symbol()->name()));
+  }
+
   void operator()(const UnresolvedNameType* type) {
     auto unit = type->translationUnit();
     SourceLocation first;

--- a/src/parser/cxx/type_traits.h
+++ b/src/parser/cxx/type_traits.h
@@ -970,6 +970,11 @@ class TypeTraits {
       return type->symbol() == otherType->symbol();
     }
 
+    auto operator()(const TemplateTypeParameterType* type,
+                    const TemplateTypeParameterType* otherType) const -> bool {
+      return type->symbol() == otherType->symbol();
+    }
+
     auto operator()(const UnresolvedNameType* type,
                     const UnresolvedNameType* otherType) const -> bool {
       return type == otherType;

--- a/src/parser/cxx/types.h
+++ b/src/parser/cxx/types.h
@@ -418,6 +418,20 @@ class TypeParameterType final : public Type,
   }
 };
 
+class TemplateTypeParameterType final
+    : public Type,
+      public std::tuple<TemplateTypeParameterSymbol*> {
+ public:
+  static constexpr TypeKind Kind = TypeKind::kTypeParameter;
+
+  explicit TemplateTypeParameterType(TemplateTypeParameterSymbol* symbol)
+      : Type(Kind), tuple(symbol) {}
+
+  [[nodiscard]] auto symbol() const -> TemplateTypeParameterSymbol* {
+    return std::get<0>(*this);
+  }
+};
+
 class UnresolvedNameType final
     : public Type,
       public std::tuple<TranslationUnit*, NestedNameSpecifierAST*,

--- a/src/parser/cxx/types_fwd.h
+++ b/src/parser/cxx/types_fwd.h
@@ -62,6 +62,7 @@ namespace cxx {
   V(MemberFunctionPointer)        \
   V(Namespace)                    \
   V(TypeParameter)                \
+  V(TemplateTypeParameter)        \
   V(UnresolvedName)               \
   V(UnresolvedBoundedArray)       \
   V(UnresolvedUnderlying)         \


### PR DESCRIPTION
This pull request updates the CI workflow to use macOS 14 and updates the libfmt dependency to version 10.2.1. It also adds a type for the template-type parameters.