### PR TITLE
fix: Make builtin type traits available as identifiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,26 @@ jobs:
         run: |
           ctest --output-on-failure
 
-      - name: Parse C++ source files
+      - name: Parse C++ source files (WASI toolchain)
         run: |
           for i in src/parser/cxx/*.cc src/frontend/cxx/*.cc; do
             echo "Parsing $i"
             ./build/src/frontend/cxx \
+              -I src/parser \
+              -I build/_deps/fmt-src/include \
+              -I build/_deps/utfcpp-src/source \
+              -I build/_deps/flatbuffers-src/include \
+              -I build/src/parser \
+              -DCXX_NO_FILESYSTEM \
+              $i
+          done
+
+      - name: Parse C++ source files (Linux toolchain)
+        run: |
+          for i in src/parser/cxx/*.cc src/frontend/cxx/*.cc; do
+            echo "Parsing $i"
+            ./build/src/frontend/cxx \
+              -toolchain linux \
               -I src/parser \
               -I build/_deps/fmt-src/include \
               -I build/_deps/utfcpp-src/source \

--- a/src/parser/cxx/parser.cc
+++ b/src/parser/cxx/parser.cc
@@ -5822,7 +5822,13 @@ void Parser::check_type_traits() {
   BuiltinTypeTraitKind builtinKind = BuiltinTypeTraitKind::T_NONE;
   if (!parse_type_traits_op(typeTraitLoc, builtinKind)) return;
 
+  // reset the builtin type traits to be available as identifiers
+  if (auto id = unit->identifier(typeTraitLoc)) {
+    id->setInfo(nullptr);
+  }
+
 #if false
+
   parse_warn(
       typeTraitLoc,
       cxx::format("keyword '{}' will be made available as an identifier for "


### PR DESCRIPTION
If the name of a builtin type-trait is used as an identifier, the
parser will treat following usages of the name as normal identifiers.

Also, test the linux toolchain in the CI workflow.