### PR TITLE
Disable scan for C++ modules in CMake

### DIFF
--- a/.devcontainer/features/wasi-sdk/devcontainer-feature.json
+++ b/.devcontainer/features/wasi-sdk/devcontainer-feature.json
@@ -6,6 +6,6 @@
     "ghcr.io/devcontainers/features/common-utils": {}
   },
   "containerEnv": {
-    "WASI_SDK_ROOT": "/opt/wasi-sdk"
+    "WASI_SDK_PATH": "/opt/wasi-sdk"
   }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "WASI")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
 endif()
 
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
+
 FetchContent_Declare(
     utfcpp
     URL                 https://github.com/nemtrif/utfcpp/archive/refs/tags/v4.0.5.tar.gz

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -50,7 +50,7 @@
       "binaryDir": "${sourceDir}/build.wasi",
       "cacheVariables": {
         "CMAKE_EXPORT_COMPILE_COMMANDS": "YES",
-        "CMAKE_TOOLCHAIN_FILE": "$env{WASI_SDK_ROOT}/share/cmake/wasi-sdk.cmake",
+        "CMAKE_TOOLCHAIN_FILE": "$env{WASI_SDK_PATH}/share/cmake/wasi-sdk.cmake",
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/build.wasi/install/usr",
         "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "YES",
@@ -59,7 +59,7 @@
       },
       "condition": {
         "type": "notEquals",
-        "lhs": "$env{WASI_SDK_ROOT}",
+        "lhs": "$env{WASI_SDK_PATH}",
         "rhs": ""
       }
     }
@@ -76,7 +76,9 @@
     {
       "name": "install",
       "configurePreset": "default",
-      "targets": ["install"]
+      "targets": [
+        "install"
+      ]
     },
     {
       "name": "build-emscripten",
@@ -85,7 +87,9 @@
     {
       "name": "install-emscripten",
       "configurePreset": "emscripten",
-      "targets": ["install"]
+      "targets": [
+        "install"
+      ]
     },
     {
       "name": "build-wasi",
@@ -94,7 +98,9 @@
     {
       "name": "install-wasi",
       "configurePreset": "wasi",
-      "targets": ["install"]
+      "targets": [
+        "install"
+      ]
     }
   ],
   "testPresets": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -31,7 +31,7 @@
       "cacheVariables": {
         "CMAKE_EXPORT_COMPILE_COMMANDS": "YES",
         "CMAKE_TOOLCHAIN_FILE": "$env{EMSCRIPTEN_ROOT}/cmake/Modules/Platform/Emscripten.cmake",
-        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/build.em/install/usr",
         "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "YES",
         "CXX_ENABLE_FLATBUFFERS": "NO",
@@ -51,7 +51,7 @@
       "cacheVariables": {
         "CMAKE_EXPORT_COMPILE_COMMANDS": "YES",
         "CMAKE_TOOLCHAIN_FILE": "$env{WASI_SDK_ROOT}/share/cmake/wasi-sdk.cmake",
-        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_INSTALL_PREFIX": "${sourceDir}/build.wasi/install/usr",
         "CMAKE_INTERPROCEDURAL_OPTIMIZATION": "YES",
         "CXX_ENABLE_FLATBUFFERS": "NO",


### PR DESCRIPTION
It seems to break the wasi build in certain cases, so we'll disable it for now.