### PR TITLE
Fix LSP unit test discovery and vector ownership

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,12 @@ if (CXX_ENABLE_FLATBUFFERS)
     set_target_properties(flatbuffers::header-only PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${flatbuffers_SOURCE_DIR}/include")
 endif()
 
+
+if (CXX_BUILD_TESTS)
+    enable_testing()
+endif()
+
+
 if (NOT KWGEN_EXECUTABLE AND CMAKE_SYSTEM_NAME STREQUAL "WASI")
 
     ExternalProject_Add(

--- a/packages/cxx-gen-lsp/src/gen_fwd_h.ts
+++ b/packages/cxx-gen-lsp/src/gen_fwd_h.ts
@@ -51,6 +51,9 @@ public:
   [[nodiscard]] auto size() const -> std::size_t { return repr_->size(); }
   [[nodiscard]] auto empty() const -> bool { return repr_->empty(); }
   [[nodiscard]] auto at(int index) const -> const T& { return repr_->at(index); }
+
+  template <typename... Args>
+  void emplace_back(Args&&... args) { repr_->emplace_back(std::forward<Args>(args)...); }
 };
 
 namespace details {
@@ -160,6 +163,22 @@ struct TryEmplace<TextDocumentSyncKind> {
 };
 
 }  // namespace details
+
+template <>
+class Vector<std::string> final : public LSPObject {
+  public:
+  using LSPObject::LSPObject;
+
+  [[nodiscard]] explicit operator bool() const { return repr_ && repr_->is_array(); }
+  [[nodiscard]] auto size() const -> std::size_t { return repr_->size(); }
+  [[nodiscard]] auto empty() const -> bool { return repr_->empty(); }
+  [[nodiscard]] auto at(int index) const -> std::string {
+    return repr_->at(index);
+  }
+
+  template <typename... Args>
+  void emplace_back(Args&&... args) { repr_->emplace_back(std::forward<Args>(args)...); }
+};
 
 template <typename... Ts>
 class Vector<std::variant<Ts...>> final : public LSPObject {

--- a/packages/cxx-gen-lsp/src/gen_fwd_h.ts
+++ b/packages/cxx-gen-lsp/src/gen_fwd_h.ts
@@ -193,6 +193,18 @@ class Vector<std::variant<Ts...>> final : public LSPObject {
     details::try_emplace(result, repr_->at(index));
     return result;
   }
+
+  template <typename T>
+  [[nodiscard]] auto emplace_back() -> std::variant<Ts...> {
+    std::variant<Ts...> result;
+    details::TryEmplace<T>{}(result, repr_->emplace_back());
+    return result;
+  }
+
+  template <std::derived_from<LSPObject> T>
+  [[nodiscard]] auto emplace_back() -> T {
+    return T(repr_->emplace_back());
+  }
 };
 
 template <typename Key, typename Value>
@@ -272,6 +284,7 @@ export function gen_fwd_h({ model, outputDirectory }: { model: MetaModel; output
   emit(`#pragma once`);
   emit();
   emit(`#include <nlohmann/json.hpp>`);
+  emit(`#include <concepts>`);
   emit(`#include <variant>`);
   emit();
   emit(`namespace cxx::lsp {`);

--- a/src/lsp/cxx/lsp/fwd.h
+++ b/src/lsp/cxx/lsp/fwd.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <nlohmann/json.hpp>
 #include <variant>
 
@@ -636,6 +637,18 @@ class Vector<std::variant<Ts...>> final : public LSPObject {
     std::variant<Ts...> result;
     details::try_emplace(result, repr_->at(index));
     return result;
+  }
+
+  template <typename T>
+  [[nodiscard]] auto emplace_back() -> std::variant<Ts...> {
+    std::variant<Ts...> result;
+    details::TryEmplace<T>{}(result, repr_->emplace_back());
+    return result;
+  }
+
+  template <std::derived_from<LSPObject> T>
+  [[nodiscard]] auto emplace_back() -> T {
+    return T(repr_->emplace_back());
   }
 };
 

--- a/src/lsp/cxx/lsp/fwd.h
+++ b/src/lsp/cxx/lsp/fwd.h
@@ -487,6 +487,11 @@ class Vector final : public LSPObject {
   [[nodiscard]] auto at(int index) const -> const T& {
     return repr_->at(index);
   }
+
+  template <typename... Args>
+  void emplace_back(Args&&... args) {
+    repr_->emplace_back(std::forward<Args>(args)...);
+  }
 };
 
 namespace details {
@@ -596,6 +601,26 @@ struct TryEmplace<TextDocumentSyncKind> {
 };
 
 }  // namespace details
+
+template <>
+class Vector<std::string> final : public LSPObject {
+ public:
+  using LSPObject::LSPObject;
+
+  [[nodiscard]] explicit operator bool() const {
+    return repr_ && repr_->is_array();
+  }
+  [[nodiscard]] auto size() const -> std::size_t { return repr_->size(); }
+  [[nodiscard]] auto empty() const -> bool { return repr_->empty(); }
+  [[nodiscard]] auto at(int index) const -> std::string {
+    return repr_->at(index);
+  }
+
+  template <typename... Args>
+  void emplace_back(Args&&... args) {
+    repr_->emplace_back(std::forward<Args>(args)...);
+  }
+};
 
 template <typename... Ts>
 class Vector<std::variant<Ts...>> final : public LSPObject {

--- a/src/lsp/tests/test_types.cc
+++ b/src/lsp/tests/test_types.cc
@@ -119,3 +119,27 @@ TEST(LSP, StringArrayProperty) {
   ASSERT_EQ(textDocumentContentRegistrationOptions.schemes().at(0), "file");
   ASSERT_EQ(textDocumentContentRegistrationOptions.schemes().at(1), "http");
 }
+
+TEST(LSP, VariantArrayProperty) {
+  auto storage = json::object();
+
+  NotebookDocumentSyncRegistrationOptions
+      notebookDocumentSyncRegistrationOptions{storage};
+
+  auto notebookSelector =
+      notebookDocumentSyncRegistrationOptions.notebookSelector();
+
+  ASSERT_TRUE(notebookSelector.empty());
+
+  auto item = notebookSelector.emplace_back<NotebookDocumentFilterWithCells>();
+
+  ASSERT_FALSE(item.notebook().has_value());
+
+  item.notebook("a_notebook");
+
+  ASSERT_TRUE(item.notebook().has_value());
+
+  ASSERT_EQ(std::get<std::string>(*item.notebook()), "a_notebook");
+
+  ASSERT_EQ(notebookSelector.size(), 1);
+}

--- a/src/lsp/tests/test_types.cc
+++ b/src/lsp/tests/test_types.cc
@@ -88,5 +88,34 @@ TEST(LSP, StringProperty) {
   ASSERT_EQ(range.start().line(), 0);
   ASSERT_EQ(range.start().character(), 0);
 
+  range.start().line(1);
+  range.start().character(2);
+  range.end().line(3);
+  range.end().character(4);
+
+  ASSERT_EQ(range.start().line(), 1);
+  ASSERT_EQ(range.start().character(), 2);
+  ASSERT_EQ(range.end().line(), 3);
+  ASSERT_EQ(range.end().character(), 4);
+
   ASSERT_TRUE(location);
+}
+
+TEST(LSP, StringArrayProperty) {
+  json storage = json::object();
+
+  auto textDocumentContentRegistrationOptions =
+      TextDocumentContentRegistrationOptions{storage};
+
+  auto schemas = textDocumentContentRegistrationOptions.schemes();
+  ASSERT_TRUE(schemas.empty());
+
+  schemas.emplace_back("file");
+  schemas.emplace_back("http");
+
+  ASSERT_EQ(schemas.at(0), "file");
+  ASSERT_EQ(schemas.at(1), "http");
+
+  ASSERT_EQ(textDocumentContentRegistrationOptions.schemes().at(0), "file");
+  ASSERT_EQ(textDocumentContentRegistrationOptions.schemes().at(1), "http");
 }


### PR DESCRIPTION
Additionally, add `emplace_back` is added to the LSP vector types.