### PR TITLE
chore: Improve compatibility with gcc 13

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-  "version": 9,
+  "version": 7,
   "configurePresets": [
     {
       "name": "default",

--- a/src/parser/cxx/parser.cc
+++ b/src/parser/cxx/parser.cc
@@ -1302,7 +1302,9 @@ auto Parser::parse_primary_expression(ExpressionAST*& yyast,
                                       const ExprContext& ctx) -> bool {
   UnqualifiedIdAST* name = nullptr;
 
-  if (parse_this_expression(yyast)) {
+  if (parse_builtin_call_expression(yyast, ctx)) {
+    return true;
+  } else if (parse_this_expression(yyast)) {
     return true;
   } else if (parse_literal(yyast)) {
     return true;
@@ -2408,9 +2410,7 @@ auto Parser::parse_postfix_expression(ExpressionAST*& yyast,
 
 auto Parser::parse_start_of_postfix_expression(ExpressionAST*& yyast,
                                                const ExprContext& ctx) -> bool {
-  if (parse_builtin_call_expression(yyast, ctx))
-    return true;
-  else if (parse_va_arg_expression(yyast, ctx))
+  if (parse_va_arg_expression(yyast, ctx))
     return true;
   else if (parse_cpp_cast_expression(yyast, ctx))
     return true;

--- a/tests/manual/source.cc
+++ b/tests/manual/source.cc
@@ -59,7 +59,11 @@
 #include <list>
 #include <locale>
 #include <map>
+
+#ifdef __cpp_lib_mdspan
 #include <mdspan>
+#endif
+
 #include <memory>
 #include <memory_resource>
 


### PR DESCRIPTION
Parse builtin type traits as primary expressions
and test for __cpp_lib_mdspan before including
<mdspan>.
