### PR TITLE
First iteration of AllocaOp, LoadOp and StoreOp

### DIFF
--- a/src/mlir/cxx/mlir/CxxOps.td
+++ b/src/mlir/cxx/mlir/CxxOps.td
@@ -99,6 +99,22 @@ def Cxx_ReturnOp : Cxx_Op<"return", [Pure, HasParent<"FuncOp">, Terminator]> {
   let hasVerifier = 0;
 }
 
+def Cxx_AllocaOp : Cxx_Op<"alloca"> {
+  let arguments = (ins);
+
+  let results = (outs Cxx_PointerType:$result);
+}
+
+def Cxx_LoadOp : Cxx_Op<"load"> {
+  let arguments = (ins Cxx_PointerType:$addr);
+
+  let results = (outs AnyType:$result);
+}
+
+def Cxx_StoreOp : Cxx_Op<"store"> {
+  let arguments = (ins AnyType:$value, Cxx_PointerType:$addr);
+}
+
 def Cxx_TodoExprOp : Cxx_Op<"todo.expr"> {
   let arguments = (ins StrAttr:$message);
   let results = (outs Cxx_ExprType:$result);

--- a/src/mlir/cxx/mlir/codegen.h
+++ b/src/mlir/cxx/mlir/codegen.h
@@ -203,6 +203,8 @@ class Codegen {
   mlir::ModuleOp module_;
   mlir::cxx::FuncOp function_;
   TranslationUnit* unit_ = nullptr;
+  mlir::Block* exitBlock_ = nullptr;
+  mlir::cxx::AllocaOp exitValue_;
   int count_ = 0;
 };
 


### PR DESCRIPTION
They are missing traits, custom builders and
assembly labels.

Fixes #616

```c
void f() {}

int main(int argc, char** argv) {}
```

$ cxx x.c -emit-ir

```c
!i32s = !cxx.int<32, true>
module @x.c {
  cxx.func @f() {
    cf.br ^bb1
  ^bb1:  // pred: ^bb0
    "cxx.return"() : () -> ()
  }
  cxx.func @main(%arg0: !i32s, %arg1: !cxx.ptr<!cxx.ptr<!cxx.expr>>) -> !i32s {
    %0 = "cxx.alloca"() : () -> !cxx.ptr<!i32s>
    cf.br ^bb1(%0 : !cxx.ptr<!i32s>)
  ^bb1(%1: !cxx.ptr<!i32s>):  // pred: ^bb0
    %2 = "cxx.load"(%0) : (!cxx.ptr<!i32s>) -> !i32s
    "cxx.return"(%2) : (!i32s) -> ()
  }
}
```