### PR TITLE
Lower cxx to the LLVM dialect

### DIFF
--- a/src/mlir/cxx/mlir/CMakeLists.txt
+++ b/src/mlir/cxx/mlir/CMakeLists.txt
@@ -28,10 +28,11 @@ target_include_directories(cxx-mlir
 
 target_link_libraries(cxx-mlir PUBLIC
     cxx-parser
-    MLIRIR
-    MLIRFuncDialect
     MLIRControlFlowDialect
-    MLIRSCFDialect
+    MLIRControlFlowToLLVM
+    MLIRIR
+    MLIRLLVMCommonConversion
+    MLIRLLVMDialect
     MLIRPass
     MLIRTransforms
 )

--- a/src/mlir/cxx/mlir/CxxOps.td
+++ b/src/mlir/cxx/mlir/CxxOps.td
@@ -28,10 +28,7 @@ def Cxx_Dialect : Dialect {
   let name = "cxx";
   let cppNamespace = "mlir::cxx";
   let useDefaultTypePrinterParser = 1;
-  let dependentDialects = ["mlir::func::FuncDialect",
-                           "mlir::cf::ControlFlowDialect",
-                           "mlir::scf::SCFDialect",
-  ];
+  let dependentDialects = ["mlir::cf::ControlFlowDialect" ];
 }
 
 class Cxx_Type<string name, string typeMnemonic, list<Trait> traits = []>

--- a/src/mlir/cxx/mlir/cxx_dialect_conversions.h
+++ b/src/mlir/cxx/mlir/cxx_dialect_conversions.h
@@ -25,7 +25,7 @@
 
 namespace cxx {
 
-[[nodiscard]] auto createLowerToFuncPass() -> std::unique_ptr<mlir::Pass>;
+[[nodiscard]] auto createLowerToLLVMPass() -> std::unique_ptr<mlir::Pass>;
 
 [[nodiscard]] auto lowerToMLIR(mlir::ModuleOp module) -> mlir::LogicalResult;
 


### PR DESCRIPTION
Barely enough to get started to lower cxx to the MLIR LLVM dialect.

cat x.c

```c
int main() { return 123; }
```

cxx -toolchain macos -emit-ir x.c
```c
module @x.c {
  llvm.func @main() -> i32 {
    %0 = llvm.mlir.constant(1 : i64) : i64
    %1 = llvm.alloca %0 x i32 : (i64) -> !llvm.ptr
    %2 = llvm.mlir.constant(123 : i64) : i32
    llvm.store %2, %1 : i32, !llvm.ptr
    llvm.br ^bb1(%1 : !llvm.ptr)
  ^bb1(%3: !llvm.ptr):  // pred: ^bb0
    %4 = llvm.load %1 : !llvm.ptr -> i32
    llvm.return %4 : i32
  }
}
```

cxx -toolchain macos -emit-ir x.c | mlir-translate --mlir-to-llvmir
```as
; ModuleID = 'LLVMDialectModule'
source_filename = "LLVMDialectModule"

define i32 @main() {
  %1 = alloca i32, i64 1, align 4
  store i32 123, ptr %1, align 4
  br label %2

2:                                                ; preds = %0
  %3 = phi ptr [ %1, %0 ]
  %4 = load i32, ptr %1, align 4
  ret i32 %4
}

!llvm.module.flags = !{!0}

!0 = !{i32 2, !"Debug Info Version", i32 3}
```

cxx -toolchain macos -emit-ir x.c | mlir-translate --mlir-to-llvmir | llc
```as
        .build_version macos, 15, 0
        .section        __TEXT,__text,regular,pure_instructions
        .globl  _main                           ; -- Begin function main
        .p2align        2
_main:                                  ; @main
        .cfi_startproc
; %bb.0:
        sub     sp, sp, #16
        .cfi_def_cfa_offset 16
        mov     w8, #123                        ; =0x7b
        mov     w0, #123                        ; =0x7b
        str     w8, [sp, #12]
        add     sp, sp, #16
        ret
        .cfi_endproc
                                        ; -- End function
.subsections_via_symbols
```

cxx -toolchain macos -emit-ir x.c | mlir-translate --mlir-to-llvmir | lli
echo $?

```
123
```