### PR TITLE
Add, Sub, Mul,and bool conversions with lowering patterns

### DIFF
--- a/src/mlir/cxx/mlir/CxxOps.td
+++ b/src/mlir/cxx/mlir/CxxOps.td
@@ -170,10 +170,46 @@ def Cxx_FloatConstantOp : Cxx_Op<"constant.float", [
   let results = (outs Cxx_FloatType:$result);
 }
 
-def Cxx_IntegralCastOp : Cxx_Op<"cast.integral"> {
+def Cxx_IntToBoolOp : Cxx_Op<"int_to_bool"> {
   let arguments = (ins AnyType:$value);
 
-  let results = (outs AnyType:$result);
+  let results = (outs Cxx_BoolType:$result);
+}
+
+def Cxx_BoolToIntOp : Cxx_Op<"bool_to_int"> {
+  let arguments = (ins Cxx_BoolType:$value);
+
+  let results = (outs Cxx_IntegerType:$result);
+}
+
+def Cxx_IntegralCastOp : Cxx_Op<"integral_cast"> {
+  let arguments = (ins Cxx_IntegerType:$value);
+
+  let results = (outs Cxx_IntegerType:$result);
+}
+
+def Cxx_NotOp : Cxx_Op<"not"> {
+  let arguments = (ins Cxx_BoolType:$value);
+
+  let results = (outs Cxx_BoolType:$result);
+}
+
+def Cxx_AddIOp : Cxx_Op<"addi"> {
+  let arguments = (ins Cxx_IntegerType:$lhs, Cxx_IntegerType:$rhs);
+
+  let results = (outs Cxx_IntegerType:$result);
+}
+
+def Cxx_SubIOp : Cxx_Op<"subi"> {
+  let arguments = (ins Cxx_IntegerType:$lhs, Cxx_IntegerType:$rhs);
+
+  let results = (outs Cxx_IntegerType:$result);
+}
+
+def Cxx_MulIOp : Cxx_Op<"muli"> {
+  let arguments = (ins Cxx_IntegerType:$lhs, Cxx_IntegerType:$rhs);
+
+  let results = (outs Cxx_IntegerType:$result);
 }
 
 //


### PR DESCRIPTION
barely enough for:

```c
int add() { return 1 + 2; }
int sub() { return 5 - 3; }
int mul() { return 4 * 2; }
int unary_not() { return !true; }
int unary_not1() { return !false; }
bool to_bool() {
  int i = 0;
  return i;
}
int to_int() {
  bool b = true;
  return b;
}
```

```bash
$ cxx x.c -emit-ir | mlir-translate -mlir-to-llvmir  |lli --entry-function=add; echo $? 
3

$ cxx x.c -emit-ir | mlir-translate -mlir-to-llvmir  |lli --entry-function=sub; echo $?
2

$ cxx x.c -emit-ir | mlir-translate -mlir-to-llvmir  |lli --entry-function=mul; echo $?
8

$ cxx x.c -emit-ir | mlir-translate -mlir-to-llvmir  |lli --entry-function=unary_not; echo $?
0

$ cxx x.c -emit-ir | mlir-translate -mlir-to-llvmir  |lli --entry-function=unary_not1; echo $?
1

$ cxx x.c -emit-ir | mlir-translate -mlir-to-llvmir  |lli --entry-function=to_bool; echo $?
0

$ cxx x.c -emit-ir | mlir-translate -mlir-to-llvmir  |lli --entry-function=to_int; echo $?
1
```