### PR TITLE
Add unstructured control flow for for-loop, break and continue

### DIFF
--- a/src/mlir/cxx/mlir/codegen.h
+++ b/src/mlir/cxx/mlir/codegen.h
@@ -263,6 +263,16 @@ class Codegen {
   void branch(mlir::Location loc, mlir::Block* block,
               mlir::ValueRange operands = {});
 
+  struct Loop {
+    mlir::Block* continueBlock = nullptr;
+    mlir::Block* breakBlock = nullptr;
+
+    Loop() = default;
+
+    Loop(mlir::Block* continueBlock, mlir::Block* breakBlock)
+        : continueBlock(continueBlock), breakBlock(breakBlock) {}
+  };
+
   struct UnitVisitor;
   struct DeclarationVisitor;
   struct StatementVisitor;
@@ -295,6 +305,7 @@ class Codegen {
   mlir::cxx::AllocaOp exitValue_;
   std::unordered_map<ClassSymbol*, mlir::Type> classNames_;
   std::unordered_map<Symbol*, mlir::Value> locals_;
+  Loop loop_;
   int count_ = 0;
 };
 


### PR DESCRIPTION
```c
int for_loop() {
  int x = 0;
  for (int i = 10; i; i = i - 1) x = x + 1;
  return x;
}

int break_loop() {
  int x = 0;
  for (int i = 10; i; i = i - 1) {
    if (!(i - 5)) break;
    x = x + 1;
  }
  return x;
}

int continue_loop() {
  int x = 0;
  for (int i = 10; i; i = i - 1) {
    if (!(i - 5)) continue;
    x = x + 1;
  }
  return x;
}
```

```
$ cxx x.c -emit-ir | mlir-translate -mlir-to-llvmir  |lli --entry-function=for_loop; echo $?
10

$ cxx x.c -emit-ir | mlir-translate -mlir-to-llvmir  |lli --entry-function=break_loop; echo $?
5

$ cxx x.c -emit-ir | mlir-translate -mlir-to-llvmir  |lli --entry-function=continue_loop; echo $?
9
```