### PR TITLE
Add goto and labels and dialect conversions to MLIR

### DIFF
--- a/src/mlir/cxx/mlir/CxxOps.td
+++ b/src/mlir/cxx/mlir/CxxOps.td
@@ -212,6 +212,14 @@ def Cxx_MulIOp : Cxx_Op<"muli"> {
   let results = (outs Cxx_IntegerType:$result);
 }
 
+def Cxx_LabelOp : Cxx_Op<"label"> {
+  let arguments = (ins StringProp:$name);
+}
+
+def Cxx_GotoOp : Cxx_Op<"goto"> {
+  let arguments = (ins StringProp:$label);
+}
+
 def CondBranchOp : Cxx_Op<"cond_br", [ AttrSizedOperandSegments, Terminator ]> {
   let arguments = (ins Cxx_BoolType:$condition, Variadic<AnyType>:$trueDestOperands, Variadic<AnyType>:$falseDestOperands);
 

--- a/src/mlir/cxx/mlir/codegen.cc
+++ b/src/mlir/cxx/mlir/codegen.cc
@@ -41,7 +41,9 @@ auto Codegen::control() const -> Control* { return unit_->control(); }
 
 auto Codegen::currentBlockMightHaveTerminator() -> bool {
   auto block = builder_.getInsertionBlock();
-  if (!block) return true;
+  if (!block) {
+    cxx_runtime_error("current block is null");
+  }
   return block->mightHaveTerminator();
 }
 

--- a/src/mlir/cxx/mlir/codegen.h
+++ b/src/mlir/cxx/mlir/codegen.h
@@ -22,9 +22,12 @@
 
 #include <cxx/ast_fwd.h>
 #include <cxx/mlir/cxx_dialect.h>
+#include <cxx/names_fwd.h>
 #include <cxx/source_location.h>
 #include <cxx/symbols_fwd.h>
 #include <cxx/types_fwd.h>
+
+// mlir
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinOps.h>

--- a/src/mlir/cxx/mlir/codegen_declarations.cc
+++ b/src/mlir/cxx/mlir/codegen_declarations.cc
@@ -369,7 +369,7 @@ auto Codegen::DeclarationVisitor::operator()(FunctionDefinitionAST* ast)
     exitValue = gen.builder_.create<mlir::cxx::AllocaOp>(exitValueLoc, ptrType);
   }
 
-  // restore state
+  // function state
   std::swap(gen.function_, func);
   std::swap(gen.exitBlock_, exitBlock);
   std::swap(gen.exitValue_, exitValue);


### PR DESCRIPTION
Enough for

```c
int goto_loop1() {
  int i = 0;

loop:
  if (i - 10) {
    i = i + 1;
    goto loop;
  }

  return i;
}

int goto_loop2() {
  int i;
  i = 10;
  goto L;
L:
  i = i + 1;
  i = i + 2;
  return i;
}
```

```bash
$ cxx x.c -emit-ir | mlir-translate -mlir-to-llvmir  |lli --entry-function=goto_loop1; echo $?
10

$ cxx x.c -emit-ir | mlir-translate -mlir-to-llvmir  |lli --entry-function=goto_loop2; echo $?
13
```