### PR TITLE
Add enough MLIR ops to the factorial

### DIFF
--- a/src/mlir/cxx/mlir/CxxOps.td
+++ b/src/mlir/cxx/mlir/CxxOps.td
@@ -21,9 +21,10 @@
 include "mlir/IR/OpBase.td"
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/SymbolInterfaces.td"
+include "mlir/IR/BuiltinAttributeInterfaces.td"
+include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/FunctionInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
-include "mlir/IR/BuiltinAttributeInterfaces.td"
 
 def Cxx_Dialect : Dialect {
   let name = "cxx";
@@ -103,9 +104,6 @@ def Cxx_FuncOp : Cxx_Op<"func", [FunctionOpInterface, IsolatedFromAbove]> {
 
   let regions = (region AnyRegion:$body);
 
-  let builders = [OpBuilder<(ins "StringRef":$name, "FunctionType":$type,
-      CArg<"ArrayRef<NamedAttribute>", "{}">:$attrs)>];
-
   let extraClassDeclaration = [{
     auto getArgumentTypes() -> ArrayRef<Type> { return getFunctionType().getInputs(); }
     auto getResultTypes() -> ArrayRef<Type> { return getFunctionType().getResults(); }
@@ -113,7 +111,6 @@ def Cxx_FuncOp : Cxx_Op<"func", [FunctionOpInterface, IsolatedFromAbove]> {
   }];
 
   let hasCustomAssemblyFormat = 1;
-  let skipDefaultBuilders = 1;
 }
 
 def Cxx_ReturnOp : Cxx_Op<"return", [Pure, HasParent<"FuncOp">, Terminator]> {
@@ -126,6 +123,17 @@ def Cxx_ReturnOp : Cxx_Op<"return", [Pure, HasParent<"FuncOp">, Terminator]> {
   }];
 
   let hasVerifier = 0;
+}
+
+def Cxx_CallOp : Cxx_Op<"call"> {
+  let arguments = (ins
+    FlatSymbolRefAttr:$callee,
+    Variadic<AnyType>:$inputs,
+    OptionalAttr<DictArrayAttr>:$arg_attrs,
+    OptionalAttr<DictArrayAttr>:$res_attrs
+  );
+
+  let results = (outs AnyType);
 }
 
 def Cxx_AllocaOp : Cxx_Op<"alloca"> {

--- a/src/mlir/cxx/mlir/codegen.h
+++ b/src/mlir/cxx/mlir/codegen.h
@@ -259,6 +259,9 @@ class Codegen {
 
   [[nodiscard]] auto currentBlockMightHaveTerminator() -> bool;
 
+  [[nodiscard]] auto findOrCreateFunction(FunctionSymbol* functionSymbol)
+      -> mlir::cxx::FuncOp;
+
   [[nodiscard]] auto findOrCreateLocal(Symbol* symbol)
       -> std::optional<mlir::Value>;
 
@@ -308,6 +311,7 @@ class Codegen {
   mlir::cxx::AllocaOp exitValue_;
   std::unordered_map<ClassSymbol*, mlir::Type> classNames_;
   std::unordered_map<Symbol*, mlir::Value> locals_;
+  std::unordered_map<FunctionSymbol*, mlir::cxx::FuncOp> funcOps_;
   Loop loop_;
   int count_ = 0;
 };

--- a/src/mlir/cxx/mlir/cxx_dialect.cc
+++ b/src/mlir/cxx/mlir/cxx_dialect.cc
@@ -122,11 +122,6 @@ void CxxDialect::initialize() {
   addInterface<CxxGenerateAliases>();
 }
 
-void FuncOp::build(OpBuilder &builder, OperationState &state, StringRef name,
-                   FunctionType type, ArrayRef<NamedAttribute> attrs) {
-  buildWithEntryBlock(builder, state, name, type, attrs, type.getInputs());
-}
-
 void FuncOp::print(OpAsmPrinter &p) {
   function_interface_impl::printFunctionOp(
       p, *this, /*isVariadic=*/false, getFunctionTypeAttrName(),


### PR DESCRIPTION
Fixes #617

```c
int fact(int n) {
  if (n <= 1) return 1;
  return n * fact(n - 1);
}

int main() {
  int result = fact(5);
  return result;
}
```


```c
$ cxx fact.c -emit-ir

module @fact.c {
  llvm.func @main() -> i32 {
    %0 = llvm.mlir.constant(5 : i32) : i32
    %1 = llvm.mlir.constant(1 : i64) : i64
    %2 = llvm.alloca %1 x i32 : (i64) -> !llvm.ptr
    %3 = llvm.alloca %1 x i32 : (i64) -> !llvm.ptr
    %4 = llvm.call @fact(%0) : (i32) -> i32
    llvm.store %4, %3 : i32, !llvm.ptr
    %5 = llvm.load %3 : !llvm.ptr -> i32
    llvm.store %5, %2 : i32, !llvm.ptr
    llvm.br ^bb1
  ^bb1:  // pred: ^bb0
    %6 = llvm.load %2 : !llvm.ptr -> i32
    llvm.return %6 : i32
  }
  llvm.func @fact(%arg0: i32) -> i32 {
    %0 = llvm.mlir.constant(1 : i32) : i32
    %1 = llvm.mlir.constant(1 : i64) : i64
    %2 = llvm.alloca %1 x i32 : (i64) -> !llvm.ptr
    %3 = llvm.alloca %1 x i32 : (i64) -> !llvm.ptr
    llvm.store %arg0, %3 : i32, !llvm.ptr
    %4 = llvm.load %3 : !llvm.ptr -> i32
    %5 = llvm.icmp "sle" %4, %0 : i32
    llvm.cond_br %5, ^bb2, ^bb3
  ^bb1:  // 2 preds: ^bb2, ^bb4
    %6 = llvm.load %2 : !llvm.ptr -> i32
    llvm.return %6 : i32
  ^bb2:  // pred: ^bb0
    llvm.store %0, %2 : i32, !llvm.ptr
    llvm.br ^bb1
  ^bb3:  // pred: ^bb0
    llvm.br ^bb4
  ^bb4:  // pred: ^bb3
    %7 = llvm.load %3 : !llvm.ptr -> i32
    %8 = llvm.load %3 : !llvm.ptr -> i32
    %9 = llvm.sub %8, %0 : i32
    %10 = llvm.call @fact(%9) : (i32) -> i32
    %11 = llvm.mul %7, %10 : i32
    llvm.store %11, %2 : i32, !llvm.ptr
    llvm.br ^bb1
  }
}
```