### PR TITLE
Implement addressof and dereference operators in codegen

### DIFF
--- a/src/mlir/cxx/mlir/codegen_expressions.cc
+++ b/src/mlir/cxx/mlir/codegen_expressions.cc
@@ -763,6 +763,16 @@ auto Codegen::ExpressionVisitor::operator()(UnaryExpressionAST* ast)
       return {op};
     }
 
+    case TokenKind::T_AMP: {
+      auto expressionResult = gen.expression(ast->expression);
+      return expressionResult;
+    }
+
+    case TokenKind::T_STAR: {
+      auto expressionResult = gen.expression(ast->expression);
+      return expressionResult;
+    }
+
     default:
       break;
   }  // switch

--- a/src/mlir/cxx/mlir/cxx_dialect_conversions.cc
+++ b/src/mlir/cxx/mlir/cxx_dialect_conversions.cc
@@ -163,7 +163,7 @@ class AllocaOpLowering : public OpConversionPattern<cxx::AllocaOp> {
     }
 
     auto size = rewriter.create<LLVM::ConstantOp>(
-        op.getLoc(), rewriter.getI64Type(), rewriter.getI64IntegerAttr(1));
+        op.getLoc(), rewriter.getI64Type(), rewriter.getIndexAttr(1));
 
     auto x = rewriter.replaceOpWithNewOp<LLVM::AllocaOp>(op, resultType,
                                                          elementType, size);


### PR DESCRIPTION
```c
int ptr_1() {
  int i = 42;
  int *p = &i;
  return *p;
}

int ptr_2() {
  int i = 42;
  int *p = &i;
  i = 123;
  return *p;
}

int ptr_3() {
  int i = 123;
  return *&i;
}
```

```bash
$ x.c -emit-ir -toolchain macos |mlir-translate --mlir-to-llvmir |lli --entry-function=ptr_1; echo $?
42

$ x.c -emit-ir -toolchain macos |mlir-translate --mlir-to-llvmir |lli --entry-function=ptr_2; echo $?
123

$ x.c -emit-ir -toolchain macos |mlir-translate --mlir-to-llvmir |lli --entry-function=ptr_3; echo $?
123
```