### PR TITLE
Initial code generation for subscript operations

### DIFF
--- a/src/mlir/cxx/mlir/CxxOps.td
+++ b/src/mlir/cxx/mlir/CxxOps.td
@@ -154,6 +154,12 @@ def Cxx_StoreOp : Cxx_Op<"store"> {
   let hasVerifier = 1;
 }
 
+def Cxx_SubscriptOp : Cxx_Op<"subscript"> {
+  let arguments = (ins Cxx_PointerType:$base, AnyType:$index);
+
+  let results = (outs Cxx_PointerType:$result);
+}
+
 def Cxx_BoolConstantOp : Cxx_Op<"constant.bool", [
   Pure
 ]> {

--- a/src/mlir/cxx/mlir/codegen_expressions.cc
+++ b/src/mlir/cxx/mlir/codegen_expressions.cc
@@ -453,13 +453,15 @@ auto Codegen::ExpressionVisitor::operator()(VaArgExpressionAST* ast)
 
 auto Codegen::ExpressionVisitor::operator()(SubscriptExpressionAST* ast)
     -> ExpressionResult {
-  auto op =
-      gen.emitTodoExpr(ast->firstSourceLocation(), to_string(ast->kind()));
-
-#if false
   auto baseExpressionResult = gen.expression(ast->baseExpression);
   auto indexExpressionResult = gen.expression(ast->indexExpression);
-#endif
+
+  auto loc = gen.getLocation(ast->firstSourceLocation());
+
+  auto resultType = gen.convertType(control()->add_pointer(ast->type));
+
+  auto op = gen.builder_.create<mlir::cxx::SubscriptOp>(
+      loc, resultType, baseExpressionResult.value, indexExpressionResult.value);
 
   return {op};
 }

--- a/src/mlir/cxx/mlir/cxx_dialect_conversions.cc
+++ b/src/mlir/cxx/mlir/cxx_dialect_conversions.cc
@@ -1251,6 +1251,7 @@ auto cxx::lowerToMLIR(mlir::ModuleOp module) -> mlir::LogicalResult {
 
   pm.addPass(cxx::createLowerToLLVMPass());
   pm.addPass(mlir::createCanonicalizerPass());
+  pm.addPass(mlir::createCSEPass());
 
   if (failed(pm.run(module))) {
     module.print(llvm::errs());


### PR DESCRIPTION
Introduce initial code generation for subscript operations, including local variable allocation and subscript operation lowering. Indices are not bundled yet.

```c
int main() {
  int a[10];
  for (int i = 0; i < 10; i = i + 1) a[i] = i;
  int r = 0;
  for (int i = 0; i < 10; i = i + 1) r = r + a[i];
  return r;
}
```

Enough for

```bash
$ cxx -emit-ir x.c | mlir-translate --mlir-to-llvmir |lli; echo $?
45
```