### PR TITLE
Some initial work on support string literals

### DIFF
--- a/src/mlir/cxx/mlir/CxxOps.td
+++ b/src/mlir/cxx/mlir/CxxOps.td
@@ -113,6 +113,15 @@ def Cxx_FuncOp : Cxx_Op<"func", [FunctionOpInterface, IsolatedFromAbove]> {
   let hasCustomAssemblyFormat = 1;
 }
 
+def Cxx_GlobalOp : Cxx_Op<"global"> {
+  let arguments = (ins
+      TypeAttrOf<AnyType>:$global_type
+    , UnitAttr:$constant
+    , SymbolNameAttr:$sym_name
+    , OptionalAttr<AnyAttr>:$value
+  );
+}
+
 def Cxx_ReturnOp : Cxx_Op<"return", [Pure, HasParent<"FuncOp">, Terminator]> {
   let arguments = (ins Variadic<AnyType>:$input);
 
@@ -121,8 +130,6 @@ def Cxx_ReturnOp : Cxx_Op<"return", [Pure, HasParent<"FuncOp">, Terminator]> {
   let extraClassDeclaration = [{
     bool hasOperand() { return getNumOperands() != 0; }
   }];
-
-  let hasVerifier = 0;
 }
 
 def Cxx_CallOp : Cxx_Op<"call"> {
@@ -158,6 +165,12 @@ def Cxx_SubscriptOp : Cxx_Op<"subscript"> {
   let arguments = (ins Cxx_PointerType:$base, AnyType:$index);
 
   let results = (outs Cxx_PointerType:$result);
+}
+
+def Cxx_AddressOfOp : Cxx_Op<"addressof"> {
+  let arguments = (ins FlatSymbolRefAttr:$sym_name);
+
+  let results = (outs AnyType:$result);
 }
 
 def Cxx_BoolConstantOp : Cxx_Op<"constant.bool", [

--- a/src/mlir/cxx/mlir/codegen.cc
+++ b/src/mlir/cxx/mlir/codegen.cc
@@ -56,6 +56,15 @@ auto Codegen::newBlock() -> mlir::Block* {
   return newBlock;
 }
 
+auto Codegen::newUniqueSymbolName(std::string_view prefix) -> std::string {
+  auto& uniqueName = uniqueSymbolNames_[prefix];
+  if (uniqueName == 0) {
+    uniqueName = 1;
+    return std::format("{}{}", prefix, uniqueName);
+  }
+  return std::format("{}{}", prefix, ++uniqueName);
+}
+
 void Codegen::branch(mlir::Location loc, mlir::Block* block,
                      mlir::ValueRange operands) {
   if (currentBlockMightHaveTerminator()) return;

--- a/src/mlir/cxx/mlir/codegen.h
+++ b/src/mlir/cxx/mlir/codegen.h
@@ -269,6 +269,10 @@ class Codegen {
       -> std::optional<mlir::Value>;
 
   [[nodiscard]] auto newBlock() -> mlir::Block*;
+
+  [[nodiscard]] auto newUniqueSymbolName(std::string_view prefix)
+      -> std::string;
+
   void branch(mlir::Location loc, mlir::Block* block,
               mlir::ValueRange operands = {});
 
@@ -315,6 +319,8 @@ class Codegen {
   std::unordered_map<ClassSymbol*, mlir::Type> classNames_;
   std::unordered_map<Symbol*, mlir::Value> locals_;
   std::unordered_map<FunctionSymbol*, mlir::cxx::FuncOp> funcOps_;
+  std::unordered_map<std::string_view, int> uniqueSymbolNames_;
+  std::unordered_map<const StringLiteral*, mlir::StringAttr> stringLiterals_;
   Loop loop_;
   int count_ = 0;
 };


### PR DESCRIPTION
Enough for

```c
int puts(const char*);

int main() {
  char* s = "hello";
  puts(s);
  puts("hello");

  char a[10];
  a[0] = 'a';
  a[1] = 'b';
  a[2] = 'c';
  a[3] = '\0';
  puts(a);
  return 0;
}
```                                                                                                                               

```bash
$ cxx -c x.c -toolchain macos 

$ ld x.o -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk -lSystem

$ /a.out 

hello
hello
abc
```