### PR TITLE
Add MemberOp and its lowering pattern for member access

### DIFF
--- a/src/mlir/cxx/mlir/CxxOps.td
+++ b/src/mlir/cxx/mlir/CxxOps.td
@@ -180,6 +180,12 @@ def Cxx_SubscriptOp : Cxx_Op<"subscript"> {
   let results = (outs Cxx_PointerType:$result);
 }
 
+def Cxx_MemberOp : Cxx_Op<"member"> {
+  let arguments = (ins Cxx_PointerType:$base, I32Prop:$member_index);
+
+  let results = (outs Cxx_PointerType:$result);
+}
+
 def Cxx_AddressOfOp : Cxx_Op<"addressof"> {
   let arguments = (ins FlatSymbolRefAttr:$sym_name);
 


### PR DESCRIPTION
Enough for

```c
int printf(const char* format, ...);

struct P {
  int x;
  int y;
};

int main() {
  struct P p;
  p.x = 10;
  p.y = 20;
  printf("%d + %d = %d\n", p.x, p.y, p.x + p.y);

  struct P* ptr = &p;
  printf("%d + %d = %d\n", ptr->x, ptr->y, ptr->x + ptr->y);

  ptr->x = 30;
  ptr->y = 40;
  printf("%d + %d = %d\n", ptr->x, ptr->y, ptr->x + ptr->y);
  printf("%d + %d = %d\n", p.x, p.y, p.x + p.y);

  return 0;
}
```

```bash
$ cxx -toolchain macos x.c -c

$ ld x.o -syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk -lSystem

$ ./a.out 
10 + 20 = 30
10 + 20 = 30
30 + 40 = 70
30 + 40 = 70
```