### PR TITLE
Add bitwise ops and their lowering patterns

### DIFF
--- a/src/mlir/cxx/mlir/CxxOps.td
+++ b/src/mlir/cxx/mlir/CxxOps.td
@@ -418,6 +418,25 @@ def Cxx_NotEqualFOp : Cxx_Op<"nef"> {
   let results = (outs Cxx_BoolType:$result);
 }
 
+// bitwise ops
+def Cxx_AndOp : Cxx_Op<"and"> {
+  let arguments = (ins Cxx_IntegerType:$lhs, Cxx_IntegerType:$rhs);
+
+  let results = (outs Cxx_IntegerType:$result);
+}
+
+def Cxx_OrOp : Cxx_Op<"or"> {
+  let arguments = (ins Cxx_IntegerType:$lhs, Cxx_IntegerType:$rhs);
+
+  let results = (outs Cxx_IntegerType:$result);
+}
+
+def Cxx_XorOp : Cxx_Op<"xor"> {
+  let arguments = (ins Cxx_IntegerType:$lhs, Cxx_IntegerType:$rhs);
+
+  let results = (outs Cxx_IntegerType:$result);
+}
+
 //
 // control flow ops
 //

--- a/src/mlir/cxx/mlir/codegen_expressions.cc
+++ b/src/mlir/cxx/mlir/codegen_expressions.cc
@@ -1578,7 +1578,7 @@ auto Codegen::ExpressionVisitor::operator()(BinaryExpressionAST* ast)
     }
 
     case TokenKind::T_LESS_LESS: {
-      if (control()->is_integral(ast->type)) {
+      if (control()->is_integral_or_unscoped_enum(ast->type)) {
         auto op = mlir::cxx::ShiftLeftOp::create(gen.builder_, loc, resultType,
                                                  leftExpressionResult.value,
                                                  rightExpressionResult.value);
@@ -1589,7 +1589,7 @@ auto Codegen::ExpressionVisitor::operator()(BinaryExpressionAST* ast)
     }
 
     case TokenKind::T_GREATER_GREATER: {
-      if (control()->is_integral(ast->type)) {
+      if (control()->is_integral_or_unscoped_enum(ast->type)) {
         auto op = mlir::cxx::ShiftRightOp::create(gen.builder_, loc, resultType,
                                                   leftExpressionResult.value,
                                                   rightExpressionResult.value);
@@ -1600,7 +1600,7 @@ auto Codegen::ExpressionVisitor::operator()(BinaryExpressionAST* ast)
     }
 
     case TokenKind::T_EQUAL_EQUAL: {
-      if (control()->is_integral(ast->type)) {
+      if (control()->is_integral_or_unscoped_enum(ast->type)) {
         auto op = mlir::cxx::EqualOp::create(gen.builder_, loc, resultType,
                                              leftExpressionResult.value,
                                              rightExpressionResult.value);
@@ -1618,14 +1618,14 @@ auto Codegen::ExpressionVisitor::operator()(BinaryExpressionAST* ast)
     }
 
     case TokenKind::T_EXCLAIM_EQUAL: {
-      if (control()->is_integral(ast->type)) {
+      if (control()->is_integral_or_unscoped_enum(ast->leftExpression->type)) {
         auto op = mlir::cxx::NotEqualOp::create(gen.builder_, loc, resultType,
                                                 leftExpressionResult.value,
                                                 rightExpressionResult.value);
         return {op};
       }
 
-      if (control()->is_floating_point(ast->type)) {
+      if (control()->is_floating_point(ast->leftExpression->type)) {
         auto op = mlir::cxx::NotEqualFOp::create(gen.builder_, loc, resultType,
                                                  leftExpressionResult.value,
                                                  rightExpressionResult.value);
@@ -1636,14 +1636,14 @@ auto Codegen::ExpressionVisitor::operator()(BinaryExpressionAST* ast)
     }
 
     case TokenKind::T_LESS: {
-      if (control()->is_integral(ast->type)) {
+      if (control()->is_integral_or_unscoped_enum(ast->leftExpression->type)) {
         auto op = mlir::cxx::LessThanOp::create(gen.builder_, loc, resultType,
                                                 leftExpressionResult.value,
                                                 rightExpressionResult.value);
         return {op};
       }
 
-      if (control()->is_floating_point(ast->type)) {
+      if (control()->is_floating_point(ast->leftExpression->type)) {
         auto op = mlir::cxx::LessThanFOp::create(gen.builder_, loc, resultType,
                                                  leftExpressionResult.value,
                                                  rightExpressionResult.value);
@@ -1654,14 +1654,14 @@ auto Codegen::ExpressionVisitor::operator()(BinaryExpressionAST* ast)
     }
 
     case TokenKind::T_LESS_EQUAL: {
-      if (control()->is_integral(ast->type)) {
+      if (control()->is_integral_or_unscoped_enum(ast->leftExpression->type)) {
         auto op = mlir::cxx::LessEqualOp::create(gen.builder_, loc, resultType,
                                                  leftExpressionResult.value,
                                                  rightExpressionResult.value);
         return {op};
       }
 
-      if (control()->is_floating_point(ast->type)) {
+      if (control()->is_floating_point(ast->leftExpression->type)) {
         auto op = mlir::cxx::LessEqualFOp::create(gen.builder_, loc, resultType,
                                                   leftExpressionResult.value,
                                                   rightExpressionResult.value);
@@ -1672,14 +1672,14 @@ auto Codegen::ExpressionVisitor::operator()(BinaryExpressionAST* ast)
     }
 
     case TokenKind::T_GREATER: {
-      if (control()->is_integral(ast->type)) {
+      if (control()->is_integral_or_unscoped_enum(ast->leftExpression->type)) {
         auto op = mlir::cxx::GreaterThanOp::create(
             gen.builder_, loc, resultType, leftExpressionResult.value,
             rightExpressionResult.value);
         return {op};
       }
 
-      if (control()->is_floating_point(ast->type)) {
+      if (control()->is_floating_point(ast->leftExpression->type)) {
         auto op = mlir::cxx::GreaterThanFOp::create(
             gen.builder_, loc, resultType, leftExpressionResult.value,
             rightExpressionResult.value);
@@ -1690,14 +1690,14 @@ auto Codegen::ExpressionVisitor::operator()(BinaryExpressionAST* ast)
     }
 
     case TokenKind::T_GREATER_EQUAL: {
-      if (control()->is_integral(ast->type)) {
+      if (control()->is_integral_or_unscoped_enum(ast->leftExpression->type)) {
         auto op = mlir::cxx::GreaterEqualOp::create(
             gen.builder_, loc, resultType, leftExpressionResult.value,
             rightExpressionResult.value);
         return {op};
       }
 
-      if (control()->is_floating_point(ast->type)) {
+      if (control()->is_floating_point(ast->leftExpression->type)) {
         auto op = mlir::cxx::GreaterEqualFOp::create(
             gen.builder_, loc, resultType, leftExpressionResult.value,
             rightExpressionResult.value);
@@ -1705,6 +1705,27 @@ auto Codegen::ExpressionVisitor::operator()(BinaryExpressionAST* ast)
       }
 
       break;
+    }
+
+    case TokenKind::T_CARET: {
+      auto op = mlir::cxx::XorOp::create(gen.builder_, loc, resultType,
+                                         leftExpressionResult.value,
+                                         rightExpressionResult.value);
+      return {op};
+    }
+
+    case TokenKind::T_AMP: {
+      auto op = mlir::cxx::AndOp::create(gen.builder_, loc, resultType,
+                                         leftExpressionResult.value,
+                                         rightExpressionResult.value);
+      return {op};
+    }
+
+    case TokenKind::T_BAR: {
+      auto op = mlir::cxx::OrOp::create(gen.builder_, loc, resultType,
+                                        leftExpressionResult.value,
+                                        rightExpressionResult.value);
+      return {op};
     }
 
     default:

--- a/src/mlir/cxx/mlir/cxx_dialect_conversions.cc
+++ b/src/mlir/cxx/mlir/cxx_dialect_conversions.cc
@@ -1037,6 +1037,79 @@ class GreaterEqualOpLowering : public OpConversionPattern<cxx::GreaterEqualOp> {
 };
 
 //
+// bitwise operations
+//
+
+class AndOpLowering : public OpConversionPattern<cxx::AndOp> {
+ public:
+  using OpConversionPattern::OpConversionPattern;
+
+  auto matchAndRewrite(cxx::AndOp op, OpAdaptor adaptor,
+                       ConversionPatternRewriter& rewriter) const
+      -> LogicalResult override {
+    auto typeConverter = getTypeConverter();
+    auto context = getContext();
+
+    auto resultType = typeConverter->convertType(op.getType());
+    if (!resultType) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to convert and operation type");
+    }
+
+    rewriter.replaceOpWithNewOp<LLVM::AndOp>(op, resultType, adaptor.getLhs(),
+                                             adaptor.getRhs());
+
+    return success();
+  }
+};
+
+class OrOpLowering : public OpConversionPattern<cxx::OrOp> {
+ public:
+  using OpConversionPattern::OpConversionPattern;
+
+  auto matchAndRewrite(cxx::OrOp op, OpAdaptor adaptor,
+                       ConversionPatternRewriter& rewriter) const
+      -> LogicalResult override {
+    auto typeConverter = getTypeConverter();
+    auto context = getContext();
+
+    auto resultType = typeConverter->convertType(op.getType());
+    if (!resultType) {
+      return rewriter.notifyMatchFailure(op,
+                                         "failed to convert or operation type");
+    }
+
+    rewriter.replaceOpWithNewOp<LLVM::OrOp>(op, resultType, adaptor.getLhs(),
+                                            adaptor.getRhs());
+
+    return success();
+  }
+};
+
+class XorOpLowering : public OpConversionPattern<cxx::XorOp> {
+ public:
+  using OpConversionPattern::OpConversionPattern;
+
+  auto matchAndRewrite(cxx::XorOp op, OpAdaptor adaptor,
+                       ConversionPatternRewriter& rewriter) const
+      -> LogicalResult override {
+    auto typeConverter = getTypeConverter();
+    auto context = getContext();
+
+    auto resultType = typeConverter->convertType(op.getType());
+    if (!resultType) {
+      return rewriter.notifyMatchFailure(
+          op, "failed to convert xor operation type");
+    }
+
+    rewriter.replaceOpWithNewOp<LLVM::XOrOp>(op, resultType, adaptor.getLhs(),
+                                             adaptor.getRhs());
+
+    return success();
+  }
+};
+
+//
 // floating point operations
 //
 
@@ -1469,6 +1542,10 @@ void CxxToLLVMLoweringPass::runOnOperation() {
   patterns.insert<EqualOpLowering, NotEquaOpLowering, LessThanOpLowering,
                   LessEqualOpLowering, GreaterThanOpLowering,
                   GreaterEqualOpLowering>(typeConverter, context);
+
+  // bitwise operations
+  patterns.insert<AndOpLowering, OrOpLowering, XorOpLowering>(typeConverter,
+                                                              context);
 
   // floating point operations
   patterns


### PR DESCRIPTION
should be enough to fix IR codegen on macOS when stdlib.h is included

```bash
echo '#include <stdlib.h>' | cxx -xc -toolchain macos -U__llvm__ -S -o - -emit-ir -
```

```llvm
...
  llvm.func @_OSSwapInt16(%arg0: i16) -> i16 {
    %0 = llvm.mlir.constant(8 : i32) : i32
    %1 = llvm.mlir.constant(1 : index) : i64
    %2 = llvm.alloca %1 x i16 : (i64) -> !llvm.ptr
    %3 = llvm.alloca %1 x i16 : (i64) -> !llvm.ptr
    llvm.store %arg0, %3 : i16, !llvm.ptr
    %4 = llvm.load %3 : !llvm.ptr -> i16
    %5 = llvm.sext %4 : i16 to i32
    %6 = llvm.shl %5, %0 : i32
    %7 = llvm.ashr %5, %0 : i32
    %8 = llvm.or %6, %7 : i32
    %9 = llvm.trunc %8 : i32 to i16
    llvm.store %9, %2 : i16, !llvm.ptr
    llvm.br ^bb1
  ^bb1:  // pred: ^bb0
    %10 = llvm.load %2 : !llvm.ptr -> i16
    llvm.return %10 : i16
  }
}
```