### PR TITLE
Improve parsing the WASI STL library

### DIFF
--- a/packages/cxx-frontend/src/Parser.ts
+++ b/packages/cxx-frontend/src/Parser.ts
@@ -29,6 +29,15 @@ import { asyncDisposeSymbol, disposeSymbol } from "./disposeSymbols.js";
 export const OutputCodeFormat = ["cxxir", "mlir", "llvm", "asm"] as const;
 export type OutputCodeFormat = (typeof OutputCodeFormat)[number];
 
+export const CxxStandard = [
+  "c++14",
+  "c++17",
+  "c++20",
+  "c++23",
+  "c++26",
+] as const;
+export type CxxStandard = (typeof CxxStandard)[number];
+
 export interface ParseOptions extends UnitOptions {
   /**
    * Path to the file to parse.
@@ -39,6 +48,8 @@ export interface ParseOptions extends UnitOptions {
    * Source code to parse.
    */
   source: string;
+
+  std?: CxxStandard;
 }
 
 /**

--- a/packages/cxx-frontend/src/cxx-js.d.ts
+++ b/packages/cxx-frontend/src/cxx-js.d.ts
@@ -15,6 +15,7 @@ export interface ClassHandle {
 export type UnitOptions = {
   appdir?: string | undefined;
   sysroot?: string | undefined;
+  std?: "c++14" | "c++17" | "c++20" | "c++23" | "c++26" | undefined;
   defines?: string[] | undefined;
   undefines?: string[] | undefined;
   quoteIncludePaths?: string[] | undefined;

--- a/packages/cxx-frontend/test/parser.test.mjs
+++ b/packages/cxx-frontend/test/parser.test.mjs
@@ -122,3 +122,63 @@ void test() { select("wrong"); }
     parserWithError.dispose();
   }
 });
+
+test("the std option selects the value of __cplusplus", async () => {
+  const expected = new Map([
+    ["c++14", "201402L"],
+    ["c++17", "201703L"],
+    ["c++20", "202002L"],
+    ["c++23", "202302L"],
+    ["c++26", "202400L"],
+  ]);
+
+  for (const [std, value] of expected) {
+    const parser = await Parser.parse({
+      source: `
+#if __cplusplus != ${value}
+#error __cplusplus does not match the requested standard
+#endif
+int answer() { return 42; }
+`,
+      path: `/source/${std}.cc`,
+      std,
+    });
+
+    try {
+      assert.deepEqual(
+        parser.diagnostics,
+        [],
+        `unexpected diagnostics for ${std}`,
+      );
+    } finally {
+      parser.dispose();
+    }
+  }
+});
+
+test("the std option composes with user defines and undefines", async () => {
+  const parser = await Parser.parse({
+    source: `
+#ifndef FLAG
+#error FLAG is not defined
+#endif
+#ifdef __wasm__
+#error __wasm__ was not undefined
+#endif
+#if __cplusplus != 202302L
+#error __cplusplus does not match the requested standard
+#endif
+int answer() { return 42; }
+`,
+    path: "/source/compose.cc",
+    std: "c++23",
+    defines: ["FLAG"],
+    undefines: ["__wasm__"],
+  });
+
+  try {
+    assert.deepEqual(parser.diagnostics, []);
+  } finally {
+    parser.dispose();
+  }
+});

--- a/src/frontend/cxx/cxx.cc
+++ b/src/frontend/cxx/cxx.cc
@@ -130,6 +130,10 @@ auto main(int argc, char* argv[]) -> int {
 
   const auto& inputFiles = cli.positionals();
 
+  if (cli.opt_fsyntax_only) {
+    cli.opt_fcheck = true;
+  }
+
   if (cli.opt_lsp_test) {
     cli.opt_lsp = true;
   }

--- a/src/frontend/cxx/frontend.cc
+++ b/src/frontend/cxx/frontend.cc
@@ -524,7 +524,6 @@ void Frontend::Private::parse() {
   unit_->parse(ParserConfiguration{
       .checkTypes =
           cli.opt_fcheck || needsIR() || unit_->language() == LanguageKind::kC,
-      .fuzzyTemplateResolution = true,
       .allowUnprototypedFunctions = cli.opt_fno_strict_prototypes,
       .stopParsingPredicate = [this]() -> bool {
         return diagnosticsClient_->errorLimitReached();

--- a/src/js/cxx/api.cc
+++ b/src/js/cxx/api.cc
@@ -66,6 +66,15 @@ cxx::ASTSlot getSlot;
 EMSCRIPTEN_DECLARE_VAL_TYPE(UnitOptions);
 EMSCRIPTEN_DECLARE_VAL_TYPE(DiagnosticList);
 
+auto cplusplusMacroValue(std::string_view standard) -> std::string_view {
+  if (standard == "c++14") return "201402L";
+  if (standard == "c++17") return "201703L";
+  if (standard == "c++20") return "202002L";
+  if (standard == "c++23") return "202302L";
+  if (standard == "c++26") return "202400L";
+  return {};
+}
+
 auto severityName(cxx::Severity severity) -> std::string_view {
   switch (severity) {
     case cxx::Severity::Message:
@@ -157,6 +166,16 @@ struct WrappedUnit {
       toolchain->addSystemCppIncludePaths();
       toolchain->addSystemIncludePaths();
       toolchain->addPredefinedMacros();
+
+      if (!api.isUndefined()) {
+        if (val standard = api["std"]; standard.isString()) {
+          auto value = cplusplusMacroValue(standard.as<std::string>());
+          if (!value.empty()) {
+            preprocessor->undefMacro("__cplusplus");
+            preprocessor->defineMacro("__cplusplus", std::string(value));
+          }
+        }
+      }
 
       addIncludePaths("quoteIncludePaths", [&](std::string path) {
         preprocessor->addQuoteIncludePath(std::move(path));
@@ -273,7 +292,6 @@ struct WrappedUnit {
 
     unit->parse(cxx::ParserConfiguration{
         .checkTypes = true,
-        .fuzzyTemplateResolution = true,
     });
 
     co_return val{true};
@@ -297,7 +315,9 @@ struct WrappedUnit {
     llvm::raw_os_ostream os(out);
 
     if (format == "cxxir") {
-      ir.module->print(os);
+      mlir::OpPrintingFlags flags;
+      if (debugInfo) flags.enableDebugInfo(true);
+      ir.module->print(os, flags);
       os.flush();
       return out.str();
     }
@@ -467,7 +487,7 @@ auto createUnit(std::string source, std::string filename, UnitOptions api)
 EMSCRIPTEN_BINDINGS(cxx) {
   register_type<UnitOptions>(
       "UnitOptions",
-      R"({ appdir?: string | undefined; sysroot?: string | undefined; defines?: string[] | undefined; undefines?: string[] | undefined; quoteIncludePaths?: string[] | undefined; includePaths?: string[] | undefined; systemIncludePaths?: string[] | undefined; debugInfo?: boolean | undefined; exists?: ((path: string) => boolean) | undefined; readFile?: ((path: string) => Promise<string | undefined>) | undefined })");
+      R"({ appdir?: string | undefined; sysroot?: string | undefined; std?: "c++14" | "c++17" | "c++20" | "c++23" | "c++26" | undefined; defines?: string[] | undefined; undefines?: string[] | undefined; quoteIncludePaths?: string[] | undefined; includePaths?: string[] | undefined; systemIncludePaths?: string[] | undefined; debugInfo?: boolean | undefined; exists?: ((path: string) => boolean) | undefined; readFile?: ((path: string) => Promise<string | undefined>) | undefined })");
 
   register_type<DiagnosticList>(
       "DiagnosticList",

--- a/src/lsp/cxx/lsp/cxx_document.cc
+++ b/src/lsp/cxx/lsp/cxx_document.cc
@@ -278,7 +278,6 @@ void CxxDocument::parse(std::string source) {
 
   unit.parse(ParserConfiguration{
       .checkTypes = cli.opt_fcheck,
-      .fuzzyTemplateResolution = true,
       .stopParsingPredicate = stopParsingPredicate,
       .complete = complete,
   });

--- a/src/mlir/cxx/mlir/codegen.cc
+++ b/src/mlir/cxx/mlir/codegen.cc
@@ -764,8 +764,7 @@ void Codegen::buildSubprogramAttr(FunctionSymbol* functionSymbol,
   mlir::LLVM::DIScopeAttr scope;
 
   if (functionSymbol->isImplicitObjectMemberFunction()) {
-    auto classSymbol = symbol_cast<ClassSymbol>(
-        functionSymbol->enclosingNonTemplateParametersScope());
+    auto classSymbol = symbol_cast<ClassSymbol>(functionSymbol->parent());
     scope = mlir::dyn_cast_or_null<mlir::LLVM::DIScopeAttr>(
         convertDebugType(classSymbol->type()));
   }
@@ -974,8 +973,8 @@ auto Codegen::loadEnclosingObject(mlir::Location loc, ClassSymbol* targetClass,
                                   ClassSymbol*& objectClass) -> mlir::Value {
   objectClass = targetClass;
   if (currentFunctionSymbol_) {
-    if (auto enclosing = symbol_cast<ClassSymbol>(
-            currentFunctionSymbol_->enclosingNonTemplateParametersScope())) {
+    if (auto enclosing =
+            symbol_cast<ClassSymbol>(currentFunctionSymbol_->parent())) {
       objectClass = enclosing;
     }
   }
@@ -1630,8 +1629,7 @@ auto Codegen::computeFunctionSignature(const FunctionType* functionType,
   }
 
   if (functionSymbol && functionSymbol->isImplicitObjectMemberFunction()) {
-    auto classSymbol = symbol_cast<ClassSymbol>(
-        functionSymbol->enclosingNonTemplateParametersScope());
+    auto classSymbol = symbol_cast<ClassSymbol>(functionSymbol->parent());
     inputTypes.push_back(mlir::cxx::PointerType::get(
         context_, convertType(classSymbol->type())));
   }
@@ -2167,9 +2165,7 @@ void Codegen::emitGlobalVarInit(VariableSymbol* var,
       }
 
       if (initExpr) {
-        auto result = expression(initExpr);
-        mlir::cxx::StoreOp::create(builder_, getLocation(initLoc), result.value,
-                                   addr, getAlignment(defVar->type()));
+        (void)emitPrvalueInto(addr, defVar->type(), initExpr, initLoc);
       }
     }
   }

--- a/src/mlir/cxx/mlir/codegen_declarations.cc
+++ b/src/mlir/cxx/mlir/codegen_declarations.cc
@@ -598,8 +598,7 @@ auto Codegen::DeclarationVisitor::operator()(FunctionDefinitionAST* ast)
   mlir::Value thisValue;
 
   if (functionSymbol->isImplicitObjectMemberFunction()) {
-    auto classSymbol = symbol_cast<ClassSymbol>(
-        functionSymbol->enclosingNonTemplateParametersScope());
+    auto classSymbol = symbol_cast<ClassSymbol>(functionSymbol->parent());
     auto thisType = gen.convertType(classSymbol->type());
     auto ptrType = mlir::cxx::PointerType::get(gen.context_, thisType);
 
@@ -772,8 +771,7 @@ auto Codegen::DeclarationVisitor::operator()(FunctionDefinitionAST* ast)
       mlir::cxx::ReturnOp::create(gen.builder_, endLoc, value->getResults());
     }
   } else if (gen.structorReturnsThis(functionSymbol) && gen.thisValue_) {
-    auto classSymbol = symbol_cast<ClassSymbol>(
-        functionSymbol->enclosingNonTemplateParametersScope());
+    auto classSymbol = symbol_cast<ClassSymbol>(functionSymbol->parent());
 
     auto thisPtr = gen.loadThisPointer(endLoc, classSymbol);
 

--- a/src/mlir/cxx/mlir/codegen_expressions.cc
+++ b/src/mlir/cxx/mlir/codegen_expressions.cc
@@ -21,6 +21,7 @@
 #include <cxx/ast.h>
 #include <cxx/ast_interpreter.h>
 #include <cxx/control.h>
+#include <cxx/lambda_captures.h>
 #include <cxx/literals.h>
 #include <cxx/memory_layout.h>
 #include <cxx/mlir/codegen.h>
@@ -766,39 +767,24 @@ auto Codegen::ExpressionVisitor::operator()(LambdaExpressionAST* ast)
       gen.builder_.restoreInsertionPoint(savedIP);
     }
 
-    auto loc = gen.getLocation(ast->firstSourceLocation());
-    auto mlirType = gen.convertType(classType);
-    auto ptrType = mlir::cxx::PointerType::get(gen.context_, mlirType);
-    auto closureAlloca = mlir::cxx::AllocaOp::create(
-        gen.builder_, loc, ptrType, gen.getAlignment(classType));
+    auto closure = gen.takeResultObject(ast);
+    if (!closure)
+      closure = gen.newTemp(classType, ast->firstSourceLocation()).getResult();
 
     std::vector<ExpressionResult> captureArgs;
     for (auto captureNode : ListView{ast->captureList}) {
-      ExpressionAST* initExpr = nullptr;
-      if (auto simple = ast_cast<SimpleLambdaCaptureAST>(captureNode)) {
-        initExpr = simple->initializer;
-      } else if (auto ref = ast_cast<RefLambdaCaptureAST>(captureNode)) {
-        initExpr = ref->initializer;
-      } else if (auto th = ast_cast<ThisLambdaCaptureAST>(captureNode)) {
-        initExpr = th->initializer;
-      } else if (auto initCap = ast_cast<InitLambdaCaptureAST>(captureNode)) {
-        initExpr = initCap->initializer;
-      } else if (auto refInitCap =
-                     ast_cast<RefInitLambdaCaptureAST>(captureNode)) {
-        initExpr = refInitCap->initializer;
-      }
-
+      auto initExpr = capture_initializer(captureNode);
       if (!initExpr) continue;
       captureArgs.push_back(gen.expression(initExpr));
     }
 
     if (ast->constructorSymbol) {
       (void)gen.emitCtorCall(ast->firstSourceLocation(), ast->constructorSymbol,
-                             closureAlloca, captureArgs,
+                             closure, captureArgs,
                              /*completeObject=*/true);
     }
 
-    return {closureAlloca};
+    return {closure};
   }
 
   auto op =
@@ -1066,8 +1052,7 @@ auto Codegen::ExpressionVisitor::operator()(CallExpressionAST* ast)
     if (functionSymbol = symbol_cast<FunctionSymbol>(id->symbol)) {
       if (functionSymbol->isImplicitObjectMemberFunction()) {
         auto loc = gen.getLocation(ast->firstSourceLocation());
-        auto classSymbol = symbol_cast<ClassSymbol>(
-            functionSymbol->enclosingNonTemplateParametersScope());
+        auto classSymbol = symbol_cast<ClassSymbol>(functionSymbol->parent());
 
         ClassSymbol* currentClass = nullptr;
         auto loadedThis =

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library(cxx-parser
     cxx/binder_range_for.cc
     cxx/binder_structured_bindings.cc
     cxx/bind_class.cc
+    cxx/class_template_deduction.cc
     cxx/class_value_abi.cc
     cxx/cli.cc
     cxx/const_value.cc

--- a/src/parser/cxx/ast.cc
+++ b/src/parser/cxx/ast.cc
@@ -6397,6 +6397,7 @@ auto TypeConstraintAST::clone(Arena* arena) -> TypeConstraintAST* {
 
   node->greaterLoc = greaterLoc;
   node->identifier = identifier;
+  node->symbol = symbol;
 
   return node;
 }
@@ -6410,7 +6411,7 @@ auto TypeConstraintAST::create(
     Arena* arena, NestedNameSpecifierAST* nestedNameSpecifier,
     SourceLocation identifierLoc, SourceLocation lessLoc,
     List<TemplateArgumentAST*>* templateArgumentList, SourceLocation greaterLoc,
-    const Identifier* identifier) -> TypeConstraintAST* {
+    const Identifier* identifier, ConceptSymbol* symbol) -> TypeConstraintAST* {
   auto node = new (arena) TypeConstraintAST();
   node->nestedNameSpecifier = nestedNameSpecifier;
   node->identifierLoc = identifierLoc;
@@ -6418,18 +6419,20 @@ auto TypeConstraintAST::create(
   node->templateArgumentList = templateArgumentList;
   node->greaterLoc = greaterLoc;
   node->identifier = identifier;
+  node->symbol = symbol;
   return node;
 }
 
 auto TypeConstraintAST::create(Arena* arena,
                                NestedNameSpecifierAST* nestedNameSpecifier,
                                List<TemplateArgumentAST*>* templateArgumentList,
-                               const Identifier* identifier)
-    -> TypeConstraintAST* {
+                               const Identifier* identifier,
+                               ConceptSymbol* symbol) -> TypeConstraintAST* {
   auto node = new (arena) TypeConstraintAST();
   node->nestedNameSpecifier = nestedNameSpecifier;
   node->templateArgumentList = templateArgumentList;
   node->identifier = identifier;
+  node->symbol = symbol;
   return node;
 }
 

--- a/src/parser/cxx/ast.h
+++ b/src/parser/cxx/ast.h
@@ -1996,6 +1996,7 @@ class TypeConstraintAST final : public AST {
   List<TemplateArgumentAST*>* templateArgumentList = nullptr;
   SourceLocation greaterLoc;
   const Identifier* identifier = nullptr;
+  ConceptSymbol* symbol = nullptr;
 
   void accept(ASTVisitor* visitor) override { visitor->visit(this); }
 
@@ -2010,13 +2011,14 @@ class TypeConstraintAST final : public AST {
       Arena* arena, NestedNameSpecifierAST* nestedNameSpecifier,
       SourceLocation identifierLoc, SourceLocation lessLoc,
       List<TemplateArgumentAST*>* templateArgumentList,
-      SourceLocation greaterLoc, const Identifier* identifier)
-      -> TypeConstraintAST*;
+      SourceLocation greaterLoc, const Identifier* identifier,
+      ConceptSymbol* symbol) -> TypeConstraintAST*;
 
   [[nodiscard]] static auto create(
       Arena* arena, NestedNameSpecifierAST* nestedNameSpecifier,
       List<TemplateArgumentAST*>* templateArgumentList,
-      const Identifier* identifier) -> TypeConstraintAST*;
+      const Identifier* identifier, ConceptSymbol* symbol)
+      -> TypeConstraintAST*;
 
  protected:
   TypeConstraintAST() : AST(Kind) {}

--- a/src/parser/cxx/ast_interpreter.cc
+++ b/src/parser/cxx/ast_interpreter.cc
@@ -630,8 +630,7 @@ auto ASTInterpreter::evaluateConstructor(FunctionSymbol* ctor,
   auto savedThis = thisObject_;
   thisObject_ = obj;
   auto savedConstructorClass = std::exchange(
-      currentConstructorClass_,
-      symbol_cast<ClassSymbol>(ctor->enclosingNonTemplateParametersScope()));
+      currentConstructorClass_, symbol_cast<ClassSymbol>(ctor->parent()));
 
   if (!bindParameters(ctor, args)) {
     thisObject_ = savedThis;

--- a/src/parser/cxx/ast_interpreter.h
+++ b/src/parser/cxx/ast_interpreter.h
@@ -200,6 +200,9 @@ class ASTInterpreter {
   [[nodiscard]] auto isRequirementSatisfied(RequirementAST* ast,
                                             ScopeSymbol* scope)
       -> std::optional<bool>;
+  [[nodiscard]] auto isReturnTypeRequirementSatisfied(
+      TypeConstraintAST* typeConstraint, ExpressionAST* expression)
+      -> std::optional<bool>;
   [[nodiscard]] auto newInitializer(NewInitializerAST* ast)
       -> NewInitializerResult;
   [[nodiscard]] auto memInitializer(MemInitializerAST* ast)
@@ -302,6 +305,9 @@ class ASTInterpreter {
 
   [[nodiscard]] auto fieldOwner(ExpressionAST* ast)
       -> std::shared_ptr<ConstObject>;
+
+  [[nodiscard]] auto addressOfLvalue(ExpressionAST* ast)
+      -> std::optional<ConstValue>;
 
   void pushFrame();
   void popFrame();

--- a/src/parser/cxx/ast_interpreter_expressions.cc
+++ b/src/parser/cxx/ast_interpreter_expressions.cc
@@ -25,6 +25,7 @@
 #include <cxx/const_value.h>
 #include <cxx/control.h>
 #include <cxx/dependent_types.h>
+#include <cxx/lambda_captures.h>
 #include <cxx/literals.h>
 #include <cxx/memory_layout.h>
 #include <cxx/name_lookup.h>
@@ -783,6 +784,49 @@ auto ASTInterpreter::fieldOwner(ExpressionAST* ast)
   return nullptr;
 }
 
+auto ASTInterpreter::addressOfLvalue(ExpressionAST* ast)
+    -> std::optional<ConstValue> {
+  while (auto nested = ast_cast<NestedExpressionAST>(ast))
+    ast = nested->expression;
+
+  if (auto idExpr = ast_cast<IdExpressionAST>(ast)) {
+    if (!idExpr->symbol) return std::nullopt;
+    if (symbol_cast<FieldSymbol>(idExpr->symbol)) {
+      if (auto owner = fieldOwner(ast))
+        return std::make_shared<ConstAddress>(owner, idExpr->symbol);
+      return std::nullopt;
+    }
+    return std::make_shared<ConstAddress>(idExpr->symbol);
+  }
+
+  if (auto member = ast_cast<MemberExpressionAST>(ast)) {
+    if (!symbol_cast<FieldSymbol>(member->symbol)) return std::nullopt;
+    if (auto owner = fieldOwner(ast))
+      return std::make_shared<ConstAddress>(owner, member->symbol);
+    return std::nullopt;
+  }
+
+  if (auto objLit = ast_cast<ObjectLiteralExpressionAST>(ast)) {
+    if (!objLit->symbol) return std::nullopt;
+    return std::make_shared<ConstAddress>(objLit->symbol);
+  }
+
+  if (auto subExpr = ast_cast<SubscriptExpressionAST>(ast)) {
+    auto idExpr = ast_cast<IdExpressionAST>(subExpr->baseExpression);
+    if (!idExpr || !idExpr->symbol) return std::nullopt;
+
+    auto indexVal = evaluate(subExpr->indexExpression);
+    if (!indexVal) return std::nullopt;
+
+    auto index = toInt(*indexVal);
+    if (!index) return std::nullopt;
+
+    return std::make_shared<ConstAddress>(idExpr->symbol, *index);
+  }
+
+  return std::nullopt;
+}
+
 auto ASTInterpreter::newPlacement(NewPlacementAST* ast) -> NewPlacementResult {
   if (!ast) return {};
 
@@ -954,41 +998,37 @@ auto ASTInterpreter::ExpressionVisitor::operator()(IdExpressionAST* ast)
 
 auto ASTInterpreter::ExpressionVisitor::operator()(LambdaExpressionAST* ast)
     -> ExpressionResult {
-  for (auto node : ListView{ast->captureList}) {
-    auto value = interp.lambdaCapture(node);
+  auto classType = type_cast<ClassType>(ast->type);
+  if (!classType || !classType->symbol()) return ExpressionResult{std::nullopt};
+
+  auto closure = std::make_shared<ConstObject>(classType);
+
+  auto captureFields =
+      views::members(classType->symbol()) | views::non_static_fields;
+  auto fieldIt = captureFields.begin();
+  const auto fieldEnd = captureFields.end();
+
+  for (auto captureNode : ListView{ast->captureList}) {
+    if (fieldIt == fieldEnd) return ExpressionResult{std::nullopt};
+    if (is_pack_capture(captureNode)) return ExpressionResult{std::nullopt};
+
+    auto captureField = *fieldIt;
+    ++fieldIt;
+
+    auto initializer = capture_initializer(captureNode);
+    if (!initializer) return ExpressionResult{std::nullopt};
+
+    auto value = interp.traits.is_reference(captureField->type())
+                     ? interp.addressOfLvalue(initializer)
+                     : interp.evaluate(initializer);
+    if (!value) return ExpressionResult{std::nullopt};
+
+    closure->addField(captureField, std::move(*value));
   }
 
-  for (auto node : ListView{ast->templateParameterList}) {
-    auto value = interp.templateParameter(node);
-  }
+  if (fieldIt != fieldEnd) return ExpressionResult{std::nullopt};
 
-  auto templateRequiresClauseResult =
-      interp.requiresClause(ast->templateRequiresClause);
-
-  auto parameterDeclarationClauseResult =
-      interp.parameterDeclarationClause(ast->parameterDeclarationClause);
-
-  for (auto node : ListView{ast->gnuAtributeList}) {
-    auto value = interp.attributeSpecifier(node);
-  }
-
-  for (auto node : ListView{ast->lambdaSpecifierList}) {
-    auto value = interp.lambdaSpecifier(node);
-  }
-
-  auto exceptionSpecifierResult =
-      interp.exceptionSpecifier(ast->exceptionSpecifier);
-
-  for (auto node : ListView{ast->attributeList}) {
-    auto value = interp.attributeSpecifier(node);
-  }
-
-  auto trailingReturnTypeResult =
-      interp.trailingReturnType(ast->trailingReturnType);
-  auto requiresClauseResult = interp.requiresClause(ast->requiresClause);
-  auto statementResult = interp.statement(ast->statement);
-
-  return ExpressionResult{std::nullopt};
+  return ExpressionResult{ConstValue{std::move(closure)}};
 }
 
 auto ASTInterpreter::ExpressionVisitor::operator()(FoldExpressionAST* ast)
@@ -1028,6 +1068,34 @@ auto ASTInterpreter::ExpressionVisitor::operator()(RequiresExpressionAST* ast)
   return ConstValue{true};
 }
 
+auto ASTInterpreter::isReturnTypeRequirementSatisfied(
+    TypeConstraintAST* typeConstraint, ExpressionAST* expression)
+    -> std::optional<bool> {
+  if (!typeConstraint->symbol) return std::nullopt;
+
+  auto arena = unit_->arena();
+
+  auto deducedTypeId = TypeIdAST::create(arena);
+  deducedTypeId->type = unit_->typeTraits().decltype_of(expression);
+  if (!deducedTypeId->type) return std::nullopt;
+
+  auto deducedArgument = TypeTemplateArgumentAST::create(arena);
+  deducedArgument->typeId = deducedTypeId;
+
+  List<TemplateArgumentAST*>* templateArgumentList = nullptr;
+  auto out = &templateArgumentList;
+  *out = make_list_node<TemplateArgumentAST>(arena, deducedArgument);
+  out = &(*out)->next;
+
+  for (auto argument : ListView{typeConstraint->templateArgumentList}) {
+    *out = make_list_node(arena, argument);
+    out = &(*out)->next;
+  }
+
+  return ASTRewriter::evaluateConcept(unit_, typeConstraint->symbol,
+                                      templateArgumentList);
+}
+
 auto ASTInterpreter::isRequirementSatisfied(RequirementAST* ast,
                                             ScopeSymbol* scope)
     -> std::optional<bool> {
@@ -1057,8 +1125,15 @@ auto ASTInterpreter::isRequirementSatisfied(RequirementAST* ast,
   if (auto compound = ast_cast<CompoundRequirementAST>(ast)) {
     auto valid = isValidExpression(compound->expression);
     if (!valid.has_value() || !*valid) return valid;
-    if (compound->typeConstraint || compound->noexceptLoc) return std::nullopt;
-    return true;
+
+    if (compound->noexceptLoc &&
+        TypeChecker::isPotentiallyThrowing(compound->expression))
+      return false;
+
+    if (!compound->typeConstraint) return true;
+
+    return isReturnTypeRequirementSatisfied(compound->typeConstraint,
+                                            compound->expression);
   }
 
   if (auto typeRequirement = ast_cast<TypeRequirementAST>(ast)) {
@@ -1611,42 +1686,8 @@ auto ASTInterpreter::ExpressionVisitor::operator()(UnaryExpressionAST* ast)
         return static_cast<std::intmax_t>(*offset);
       }
 
-      if (auto idExpr = ast_cast<IdExpressionAST>(innerExpr)) {
-        if (idExpr->symbol) {
-          if (symbol_cast<FieldSymbol>(idExpr->symbol)) {
-            if (auto owner = interp.fieldOwner(innerExpr))
-              return std::make_shared<ConstAddress>(owner, idExpr->symbol);
-            break;
-          }
-          return std::make_shared<ConstAddress>(idExpr->symbol);
-        }
-      }
-
-      if (auto member = ast_cast<MemberExpressionAST>(innerExpr)) {
-        if (symbol_cast<FieldSymbol>(member->symbol)) {
-          if (auto owner = interp.fieldOwner(innerExpr))
-            return std::make_shared<ConstAddress>(owner, member->symbol);
-        }
-        break;
-      }
-
-      if (auto objLit = ast_cast<ObjectLiteralExpressionAST>(innerExpr)) {
-        if (objLit->symbol) {
-          return std::make_shared<ConstAddress>(objLit->symbol);
-        }
-      }
-
-      auto subExpr = ast_cast<SubscriptExpressionAST>(innerExpr);
-      if (!subExpr) break;
-
-      auto idExpr = ast_cast<IdExpressionAST>(subExpr->baseExpression);
-      if (!idExpr || !idExpr->symbol) break;
-
-      auto indexVal = interp.evaluate(subExpr->indexExpression);
-      if (!indexVal) break;
-
-      if (auto idx = interp.toInt(*indexVal))
-        return std::make_shared<ConstAddress>(idExpr->symbol, *idx);
+      if (auto address = interp.addressOfLvalue(innerExpr))
+        return ExpressionResult{std::move(address)};
 
       break;
     }

--- a/src/parser/cxx/ast_rewriter.h
+++ b/src/parser/cxx/ast_rewriter.h
@@ -52,7 +52,9 @@ class [[nodiscard]] ASTRewriter {
                           List<TemplateArgumentAST*>* templateArgumentList,
                           Symbol* symbol, SourceLocation instantiationLoc = {},
                           bool sfinaeContext = false, bool argsComplete = false,
-                          bool declarationOnly = false) -> Symbol*;
+                          bool declarationOnly = false,
+                          bool retainEnclosingTemplateLevels = false)
+      -> Symbol*;
 
   static auto instantiateForArgs(
       TranslationUnit* unit, List<TemplateArgumentAST*>* deducedArguments,
@@ -85,6 +87,16 @@ class [[nodiscard]] ASTRewriter {
       const std::vector<TemplateArgument>& templateArguments, int depth,
       ScopeSymbol* scope) -> ExpressionAST*;
 
+  static auto substituteParameterClause(
+      TranslationUnit* unit, ParameterDeclarationClauseAST* parameters,
+      const std::vector<TemplateArgument>& templateArguments, int depth,
+      ScopeSymbol* scope) -> ParameterDeclarationClauseAST*;
+
+  static auto substituteParameterTypes(
+      TranslationUnit* unit, ParameterDeclarationClauseAST* parameters,
+      const std::vector<TemplateArgument>& templateArguments, int depth,
+      ScopeSymbol* scope) -> std::optional<std::vector<const Type*>>;
+
   static auto findPartialSpecializationPattern(
       TranslationUnit* unit, ClassSymbol* primary,
       List<TemplateArgumentAST*>* templateArgumentList) -> ClassSymbol*;
@@ -100,6 +112,21 @@ class [[nodiscard]] ASTRewriter {
 
   [[nodiscard]] auto templateArgumentFor(Symbol* templateParameter) const
       -> const TemplateArgument*;
+
+  [[nodiscard]] auto writtenArgumentForAliasedParameter(
+      TypeIdAST* patternTypeId) const -> TypeIdAST*;
+
+  [[nodiscard]] auto writtenTypeArgumentSpecifierFor(
+      Symbol* templateParameter) const -> NamedTypeSpecifierAST*;
+
+  [[nodiscard]] auto retainsEnclosingTemplateLevels() const -> bool {
+    return retainsEnclosingTemplateLevels_;
+  }
+
+  void setRetainsEnclosingTemplateLevels(bool value) {
+    retainsEnclosingTemplateLevels_ = value;
+    binder_.setRetainsEnclosingTemplateLevels(value);
+  }
 
   [[nodiscard]] auto substitutedSymbol(Symbol* templateParameter) const
       -> Symbol*;
@@ -141,6 +168,23 @@ class [[nodiscard]] ASTRewriter {
 
   void retryPendingMemberTemplateAttachment(FunctionSymbol* member);
 
+  [[nodiscard]] static auto associatedConstraints(TranslationUnit* unit,
+                                                  Symbol* symbol)
+      -> std::vector<ExpressionAST*>;
+
+  [[nodiscard]] static auto evaluateAssociatedConstraints(TranslationUnit* unit,
+                                                          Symbol* symbol)
+      -> std::optional<bool>;
+
+  [[nodiscard]] static auto checkAssociatedConstraints(
+      TranslationUnit* unit, Symbol* symbol,
+      const std::vector<TemplateArgument>& templateArguments, int depth)
+      -> bool;
+
+  [[nodiscard]] static auto typeConstraintExpression(
+      TranslationUnit* unit, ConstraintTypeParameterSymbol* parameter)
+      -> ExpressionAST*;
+
  private:
   void error(SourceLocation loc, std::string message);
   void warning(SourceLocation loc, std::string message);
@@ -156,8 +200,8 @@ class [[nodiscard]] ASTRewriter {
       TranslationUnit* unit, VariableSymbol* variableSymbol,
       const std::vector<TemplateArgument>& templateArguments) -> Symbol*;
 
-  static auto checkRequiresClause(
-      TranslationUnit* unit, Symbol* symbol, RequiresClauseAST* clause,
+  static auto checkConstraintExpression(
+      TranslationUnit* unit, Symbol* symbol, ExpressionAST* constraint,
       const std::vector<TemplateArgument>& templateArguments, int depth)
       -> bool;
 
@@ -354,6 +398,7 @@ class [[nodiscard]] ASTRewriter {
 
   TranslationUnit* unit_ = nullptr;
   std::vector<TemplateArgument> templateArguments_;
+  List<TemplateArgumentAST*>* writtenTemplateArgumentList_ = nullptr;
   std::unordered_map<int, std::vector<TemplateArgument>>
       enclosingTemplateArguments_;
   std::vector<Diagnostic> bodyErrors_;
@@ -368,6 +413,7 @@ class [[nodiscard]] ASTRewriter {
   int depth_ = 0;
   ClassSymbol* classInstanceToComplete_ = nullptr;
   bool restrictedToDeclarations_ = false;
+  bool retainsEnclosingTemplateLevels_ = false;
   bool substitutionFailed_ = false;
 
   bool instantiatingFunctionTemplateSpecialization_ = false;

--- a/src/parser/cxx/ast_rewriter_declarations.cc
+++ b/src/parser/cxx/ast_rewriter_declarations.cc
@@ -230,6 +230,7 @@ auto ASTRewriter::typeConstraint(TypeConstraintAST* ast) -> TypeConstraintAST* {
 
   copy->greaterLoc = ast->greaterLoc;
   copy->identifier = ast->identifier;
+  copy->symbol = ast->symbol;
 
   return copy;
 }
@@ -525,7 +526,8 @@ auto ASTRewriter::DeclarationVisitor::operator()(AliasDeclarationAST* ast)
 
   auto symbol = binder()->declareTypeAlias(copy->identifierLoc, copy->typeId,
                                            addSymbolToParentScope);
-  if (!addSymbolToParentScope && !rewrite.substitutionFailed()) {
+  if (!addSymbolToParentScope && !rewrite.substitutionFailed() &&
+      !rewrite.retainsEnclosingTemplateLevels()) {
     ast->symbol->addSpecialization(rewrite.templateArguments(), symbol);
   }
 
@@ -536,6 +538,7 @@ auto ASTRewriter::DeclarationVisitor::operator()(AliasDeclarationAST* ast)
 
   copy->symbol = symbol;
   symbol->setDeclaration(copy);
+  symbol->setExpansionTypeId(copy->typeId);
 
   rewrite.addSymbolRemap(ast->symbol, symbol);
 
@@ -709,10 +712,8 @@ auto ASTRewriter::DeclarationVisitor::operator()(FunctionDefinitionAST* ast)
 
   if (!rewrite.restrictedToDeclarations()) {
     if (auto oldFunc = symbol_cast<FunctionSymbol>(ast->symbol)) {
-      auto oldClass = symbol_cast<ClassSymbol>(
-          oldFunc->enclosingNonTemplateParametersScope());
-      auto newClass = symbol_cast<ClassSymbol>(
-          functionSymbol->enclosingNonTemplateParametersScope());
+      auto oldClass = symbol_cast<ClassSymbol>(oldFunc->parent());
+      auto newClass = symbol_cast<ClassSymbol>(functionSymbol->parent());
       if (oldClass && newClass && oldClass != newClass) {
         rewrite.remapScopeMembers(oldClass, newClass);
       }

--- a/src/parser/cxx/ast_rewriter_declarators.cc
+++ b/src/parser/cxx/ast_rewriter_declarators.cc
@@ -348,7 +348,7 @@ auto ASTRewriter::initDeclarator(InitDeclaratorAST* ast,
   } else if (auto variableSymbol = symbol_cast<VariableSymbol>(copy->symbol)) {
     auto typeChecker = TypeChecker{unit_};
     typeChecker.setScope(binder_.scope());
-    typeChecker.check_init_declarator(copy);
+    typeChecker.check_init_declarator(copy, declSpecs.typeSpecifier());
   }
 
   return copy;

--- a/src/parser/cxx/ast_rewriter_expressions.cc
+++ b/src/parser/cxx/ast_rewriter_expressions.cc
@@ -585,7 +585,11 @@ auto ASTRewriter::ExpressionVisitor::operator()(IdExpressionAST* ast)
         if (auto literal = spelledIntegerLiteral(var, copy->type))
           return literal;
 
-        if (var->initializer()) return rewrite.expression(var->initializer());
+        if (auto initializer = var->initializer()) {
+          if (rewrite.retainsEnclosingTemplateLevels())
+            return initializer->clone(arena());
+          return rewrite.expression(initializer);
+        }
       }
     }
   } else if (copy->nestedNameSpecifier && copy->nestedNameSpecifier->symbol) {
@@ -606,8 +610,7 @@ auto ASTRewriter::ExpressionVisitor::operator()(IdExpressionAST* ast)
         (fn->templateDeclaration() || fn->isSpecialization())) {
       auto templateId = ast_cast<SimpleTemplateIdAST>(copy->unqualifiedId);
       if (templateId && templateId->identifier) {
-        if (auto cls = symbol_cast<ClassSymbol>(
-                fn->enclosingNonTemplateParametersScope())) {
+        if (auto cls = symbol_cast<ClassSymbol>(fn->parent())) {
           if (auto instCls = symbol_cast<ClassSymbol>(rewrite.remapSymbol(cls));
               instCls && instCls != cls) {
             auto cf = views::find_function(

--- a/src/parser/cxx/ast_rewriter_instantiate.cc
+++ b/src/parser/cxx/ast_rewriter_instantiate.cc
@@ -40,33 +40,6 @@
 
 namespace cxx {
 namespace {
-struct GetDeclaration {
-  auto operator()(ClassSymbol* symbol) -> AST* { return symbol->declaration(); }
-
-  auto operator()(VariableSymbol* symbol) -> AST* {
-    auto templateDecl = symbol->templateDeclaration();
-    if (!templateDecl) return nullptr;
-    return templateDecl->declaration;
-  }
-
-  auto operator()(TypeAliasSymbol* symbol) -> AST* {
-    auto templateDecl = symbol->templateDeclaration();
-    if (!templateDecl) return nullptr;
-    return templateDecl->declaration;
-  }
-
-  auto operator()(FunctionSymbol* symbol) -> AST* {
-    if (auto declaration = symbol->declaration()) return declaration;
-
-    auto templateDecl = symbol->templateDeclaration();
-    if (!templateDecl) return nullptr;
-
-    return templateDecl->declaration;
-  }
-
-  auto operator()(Symbol*) -> AST* { return nullptr; }
-};
-
 struct GetSpecialization {
   const std::vector<TemplateArgument>& templateArguments;
 
@@ -148,6 +121,12 @@ struct Instantiate {
     auto instance =
         ast_cast<AliasDeclarationAST>(rewriter.declaration(declaration));
     if (!instance) return nullptr;
+
+    if (auto written =
+            rewriter.writtenArgumentForAliasedParameter(declaration->typeId)) {
+      if (auto alias = symbol_cast<TypeAliasSymbol>(instance->symbol))
+        alias->setExpansionTypeId(written);
+    }
 
     return instance->symbol;
   }
@@ -495,6 +474,38 @@ auto ASTRewriter::substituteDefaultExpression(
   return rewriter.expression(expression);
 }
 
+auto ASTRewriter::substituteParameterClause(
+    TranslationUnit* unit, ParameterDeclarationClauseAST* parameters,
+    const std::vector<TemplateArgument>& templateArguments, int depth,
+    ScopeSymbol* scope) -> ParameterDeclarationClauseAST* {
+  if (!parameters) return nullptr;
+
+  auto rewriter = ASTRewriter{unit, scope,
+                              std::vector<TemplateArgument>(templateArguments)};
+  rewriter.depth_ = depth;
+
+  return rewriter.parameterDeclarationClause(parameters);
+}
+
+auto ASTRewriter::substituteParameterTypes(
+    TranslationUnit* unit, ParameterDeclarationClauseAST* parameters,
+    const std::vector<TemplateArgument>& templateArguments, int depth,
+    ScopeSymbol* scope) -> std::optional<std::vector<const Type*>> {
+  if (!parameters) return std::vector<const Type*>{};
+
+  auto rewritten = substituteParameterClause(unit, parameters,
+                                             templateArguments, depth, scope);
+  if (!rewritten) return std::nullopt;
+
+  std::vector<const Type*> parameterTypes;
+  for (auto parameter : ListView{rewritten->parameterDeclarationList}) {
+    if (!parameter->type) return std::nullopt;
+    parameterTypes.push_back(parameter->type);
+  }
+
+  return parameterTypes;
+}
+
 void ASTRewriter::reportPendingInstantiationErrors(
     TranslationUnit* unit, Symbol* primaryTemplate, Symbol* instantiated,
     SourceLocation instantiationLoc) {
@@ -527,7 +538,8 @@ auto ASTRewriter::instantiate(TranslationUnit* unit,
                               List<TemplateArgumentAST*>* templateArgumentList,
                               Symbol* symbol, SourceLocation instantiationLoc,
                               bool sfinaeContext, bool argsComplete,
-                              bool declarationOnly) -> Symbol* {
+                              bool declarationOnly,
+                              bool retainEnclosingTemplateLevels) -> Symbol* {
   if (!symbol) return nullptr;
 
   if (!unit->config().checkTypes) return nullptr;
@@ -542,7 +554,7 @@ auto ASTRewriter::instantiate(TranslationUnit* unit,
   auto templateDecl = template_declaration_of(symbol);
   if (!templateDecl) return nullptr;
 
-  auto declaration = visit(GetDeclaration{}, symbol);
+  auto declaration = template_declaration_ast(symbol);
   if (!declaration) return nullptr;
 
   const bool ownsSfinaeClient = sfinaeContext && !activeClientIsSfinae;
@@ -587,7 +599,11 @@ auto ASTRewriter::instantiate(TranslationUnit* unit,
     return symbol;
   }
 
-  if (auto cached = visit(GetSpecialization{templateArguments}, symbol)) {
+  auto cached = retainEnclosingTemplateLevels
+                    ? nullptr
+                    : visit(GetSpecialization{templateArguments}, symbol);
+
+  if (cached) {
     auto cachedClass = symbol_cast<ClassSymbol>(cached);
     if (!cachedClass) {
       if (!declarationOnly) {
@@ -617,18 +633,10 @@ auto ASTRewriter::instantiate(TranslationUnit* unit,
     }
   }
 
-  if (!checkRequiresClause(unit, symbol, templateDecl->requiresClause,
-                           templateArguments, templateDecl->depth)) {
+  if (!checkAssociatedConstraints(unit, symbol, templateArguments,
+                                  templateDecl->depth)) {
     if (savedDiagClient) (void)unit->changeDiagnosticsClient(savedDiagClient);
     return nullptr;
-  }
-
-  if (auto functionDef = ast_cast<FunctionDefinitionAST>(declaration)) {
-    if (!checkRequiresClause(unit, symbol, functionDef->requiresClause,
-                             templateArguments, templateDecl->depth)) {
-      if (savedDiagClient) (void)unit->changeDiagnosticsClient(savedDiagClient);
-      return nullptr;
-    }
   }
 
   if (auto classSymbol = symbol_cast<ClassSymbol>(symbol)) {
@@ -653,6 +661,8 @@ auto ASTRewriter::instantiate(TranslationUnit* unit,
   auto rewriter = ASTRewriter{unit, parentScope, templateArguments};
   rewriter.depth_ = templateDecl->depth;
   rewriter.inheritEnclosingTemplateArguments(parentScope);
+  rewriter.writtenTemplateArgumentList_ = templateArgumentList;
+  rewriter.setRetainsEnclosingTemplateLevels(retainEnclosingTemplateLevels);
   rewriter.binder().setInstantiatingSymbol(symbol);
   rewriter.binder().setInstantiationLoc(instantiationLoc);
   if (declarationOnly) rewriter.setRestrictedToDeclarations(true);
@@ -876,13 +886,13 @@ void ASTRewriter::instantiateOutOfClassMemberDefinitions(ClassSymbol* pattern) {
   if (instanceClass) {
     auto classTemplateDecl = pattern->templateDeclaration();
     if (classTemplateDecl) {
-      for (auto instanceCtor : instanceClass->constructors()) {
+      for (auto instanceCtor : instanceClass->declaredConstructors()) {
         if (!instanceCtor->templateDeclaration()) continue;
         if (instanceCtor->declaration()) continue;
         if (instanceCtor->hasPendingBody()) continue;
 
         FunctionSymbol* patternCtor = nullptr;
-        for (auto candidate : pattern->constructors()) {
+        for (auto candidate : pattern->declaredConstructors()) {
           if (!candidate->templateDeclaration()) continue;
           if (candidate->isFriend()) continue;
           if (!areFunctionTemplateHeadsEquivalentForRedeclaration(
@@ -947,12 +957,12 @@ void ASTRewriter::instantiateOutOfClassMemberDefinitions(ClassSymbol* pattern) {
 
   if (instanceClass) {
     std::vector<FunctionSymbol*> patternCtors;
-    for (auto ctor : pattern->constructors()) {
+    for (auto ctor : pattern->declaredConstructors()) {
       if (ctor->canonical() == ctor && !ctor->isDefaulted())
         patternCtors.push_back(ctor);
     }
     std::vector<FunctionSymbol*> instanceCtors;
-    for (auto ctor : instanceClass->constructors()) {
+    for (auto ctor : instanceClass->declaredConstructors()) {
       if (ctor->canonical() == ctor && !ctor->isDefaulted())
         instanceCtors.push_back(ctor);
     }

--- a/src/parser/cxx/ast_rewriter_names.cc
+++ b/src/parser/cxx/ast_rewriter_names.cc
@@ -526,6 +526,17 @@ auto ASTRewriter::NestedNameSpecifierVisitor::operator()(
       copy->templateId->symbol = resolved;
   }
 
+  if (!copy->templateId->symbol && copy->templateId->identifier &&
+      !isDependentNestedNameSpecifier(copy->nestedNameSpecifier)) {
+    auto scopeSymbol =
+        copy->nestedNameSpecifier ? copy->nestedNameSpecifier->symbol : nullptr;
+    rewrite.error(copy->templateId->identifierLoc,
+                  std::format("no member named '{}' in '{}'",
+                              copy->templateId->identifier->value(),
+                              scopeSymbol ? to_string(scopeSymbol->type())
+                                          : std::string{"<error-type>"}));
+  }
+
   if (auto primaryClass = symbol_cast<ClassSymbol>(copy->templateId->symbol)) {
     auto instance = ASTRewriter::instantiate(
         rewrite.unit_, copy->templateId->templateArgumentList, primaryClass,

--- a/src/parser/cxx/ast_rewriter_packs.cc
+++ b/src/parser/cxx/ast_rewriter_packs.cc
@@ -162,6 +162,68 @@ auto ASTRewriter::templateArgumentFor(Symbol* templateParameter) const
   return templateArgumentAt(info->depth, info->index);
 }
 
+auto ASTRewriter::writtenArgumentForAliasedParameter(
+    TypeIdAST* patternTypeId) const -> TypeIdAST* {
+  if (!writtenTemplateArgumentList_) return nullptr;
+  if (!patternTypeId) return nullptr;
+  if (!patternTypeId->typeSpecifierList ||
+      patternTypeId->typeSpecifierList->next) {
+    return nullptr;
+  }
+
+  auto named =
+      ast_cast<NamedTypeSpecifierAST>(patternTypeId->typeSpecifierList->value);
+  if (!named || !symbol_cast<TypeParameterSymbol>(named->symbol)) {
+    return nullptr;
+  }
+
+  auto info = template_parameter_info(named->symbol);
+  if (!info || info->isPack || info->depth != depth_ || info->index < 0) {
+    return nullptr;
+  }
+
+  int index = 0;
+  for (auto argument : ListView{writtenTemplateArgumentList_}) {
+    if (index++ != info->index) continue;
+    auto typeArgument = ast_cast<TypeTemplateArgumentAST>(argument);
+    if (!typeArgument || !typeArgument->typeId) return nullptr;
+    return typeArgument->typeId->clone(arena());
+  }
+
+  return nullptr;
+}
+
+auto ASTRewriter::writtenTypeArgumentSpecifierFor(
+    Symbol* templateParameter) const -> NamedTypeSpecifierAST* {
+  if (!retainsEnclosingTemplateLevels()) return nullptr;
+
+  auto info = template_parameter_info(templateParameter);
+  if (!info || info->isPack || info->depth != depth_ || info->index < 0) {
+    return nullptr;
+  }
+
+  int index = 0;
+  for (auto argument : ListView{writtenTemplateArgumentList_}) {
+    if (index++ != info->index) continue;
+
+    auto typeArgument = ast_cast<TypeTemplateArgumentAST>(argument);
+    if (!typeArgument || !typeArgument->typeId) return nullptr;
+
+    auto typeId = typeArgument->typeId;
+    if (typeId->declarator) return nullptr;
+    if (!typeId->typeSpecifierList || typeId->typeSpecifierList->next)
+      return nullptr;
+
+    auto named =
+        ast_cast<NamedTypeSpecifierAST>(typeId->typeSpecifierList->value);
+    if (!named || !ast_cast<SimpleTemplateIdAST>(named->unqualifiedId))
+      return nullptr;
+    return named->clone(arena());
+  }
+
+  return nullptr;
+}
+
 auto ASTRewriter::substitutedSymbol(Symbol* templateParameter) const
     -> Symbol* {
   auto argument = templateArgumentFor(templateParameter);

--- a/src/parser/cxx/ast_rewriter_partial_specialization.cc
+++ b/src/parser/cxx/ast_rewriter_partial_specialization.cc
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include <functional>
 #include <map>
+#include <ranges>
 #include <span>
 
 namespace cxx {
@@ -87,16 +88,38 @@ struct NestedTemplatePattern {
   }
 };
 
-auto findTemplateIdInTypeId(TypeIdAST* typeId) -> SimpleTemplateIdAST* {
+auto expansionTypeIdOfAlias(NamedTypeSpecifierAST* named) -> TypeIdAST* {
+  auto alias = symbol_cast<TypeAliasSymbol>(named->symbol);
+  if (!alias || alias->templateDeclaration()) return nullptr;
+  return alias->expansionTypeId();
+}
+
+auto findTemplateIdInTypeId(TypeIdAST* typeId,
+                            std::vector<TypeIdAST*>& expandedAliases)
+    -> SimpleTemplateIdAST* {
   if (!typeId) return nullptr;
+  if (std::ranges::contains(expandedAliases, typeId)) return nullptr;
+  expandedAliases.push_back(typeId);
+
   for (auto sp : ListView{typeId->typeSpecifierList}) {
     auto named = ast_cast<NamedTypeSpecifierAST>(sp);
     if (!named) continue;
+
+    if (auto expansion = expansionTypeIdOfAlias(named)) {
+      if (auto templId = findTemplateIdInTypeId(expansion, expandedAliases))
+        return templId;
+    }
+
     if (auto templId = ast_cast<SimpleTemplateIdAST>(named->unqualifiedId)) {
       return templId;
     }
   }
   return nullptr;
+}
+
+auto findTemplateIdInTypeId(TypeIdAST* typeId) -> SimpleTemplateIdAST* {
+  std::vector<TypeIdAST*> expandedAliases;
+  return findTemplateIdInTypeId(typeId, expandedAliases);
 }
 
 auto extractDirectNestedTemplateIds(SimpleTemplateIdAST* templId)
@@ -138,6 +161,34 @@ auto extractNestedTemplatePattern(ClassSpecifierAST* specBody)
   return pattern;
 }
 
+struct HasDefaultTemplateArgument {
+  auto operator()(TypenameTypeParameterAST* p) const -> bool {
+    return p->typeId != nullptr;
+  }
+  auto operator()(TemplateTypeParameterAST* p) const -> bool {
+    return p->idExpression != nullptr;
+  }
+  auto operator()(ConstraintTypeParameterAST* p) const -> bool {
+    return p->typeId != nullptr;
+  }
+  auto operator()(NonTypeTemplateParameterAST* p) const -> bool {
+    return p->declaration && p->declaration->expression != nullptr;
+  }
+};
+
+auto hasDefaultsFromPosition(TemplateDeclarationAST* templateDecl,
+                             size_t fromPosition) -> bool {
+  size_t position = 0;
+  for (auto parameter : ListView{templateDecl->templateParameterList}) {
+    if (position >= fromPosition &&
+        !visit(HasDefaultTemplateArgument{}, parameter)) {
+      return false;
+    }
+    ++position;
+  }
+  return true;
+}
+
 auto asSymbolArgument(const TemplateArgument& argument) -> Symbol* {
   auto symbol = std::get_if<Symbol*>(&argument);
   if (!symbol) return nullptr;
@@ -155,8 +206,54 @@ struct PartialSpecMatcher {
   int nestedMatches = 0;
   int nonTypeMatches = 0;
   int deducedParamMatches = 0;
+  int templateTemplateBindings = 0;
 
   [[nodiscard]] auto control() const -> Control* { return unit->control(); }
+
+  static auto toSymbolVector(std::span<const TemplateArgument> args)
+      -> std::vector<Symbol*> {
+    std::vector<Symbol*> result;
+    result.reserve(args.size());
+
+    for (const auto& arg : args) result.push_back(asSymbolArgument(arg));
+
+    return result;
+  }
+
+  auto collectWrittenTemplateArgumentSymbols(List<TemplateArgumentAST*>* args)
+      -> std::optional<std::vector<Symbol*>> {
+    std::vector<Symbol*> symbols;
+    for (auto arg : ListView{args}) {
+      if (auto typeArg = ast_cast<TypeTemplateArgumentAST>(arg)) {
+        if (!typeArg->typeId || !typeArg->typeId->type) return std::nullopt;
+        auto wrapper = control()->newTypeAliasSymbol(nullptr, {});
+        wrapper->setType(typeArg->typeId->type);
+        symbols.push_back(wrapper);
+        continue;
+      }
+
+      if (auto exprArg = ast_cast<ExpressionTemplateArgumentAST>(arg)) {
+        auto idExpr = ast_cast<IdExpressionAST>(exprArg->expression);
+        if (!idExpr || !idExpr->symbol) return std::nullopt;
+        symbols.push_back(idExpr->symbol);
+        continue;
+      }
+
+      return std::nullopt;
+    }
+    return symbols;
+  }
+
+  auto finishNestedMatch(const std::vector<Symbol*>& patSymbols,
+                         const std::vector<Symbol*>& concSymbols,
+                         SimpleTemplateIdAST* patTemplId) -> bool {
+    if (!deduceArgumentList(patSymbols, concSymbols, patTemplId, 0)) {
+      return false;
+    }
+    ++score;
+    ++nestedMatches;
+    return true;
+  }
 
   auto sameArgument(Symbol* lhs, Symbol* rhs) const -> bool {
     if (lhs == rhs) return true;
@@ -244,6 +341,15 @@ struct PartialSpecMatcher {
       -> bool {
     if (!patSym || !concSym) return false;
 
+    auto childTemplateId =
+        pattern ? pattern->child(patTemplId, argPos) : nullptr;
+
+    if (auto patTTP = type_cast<TemplateTypeParameterType>(patSym->type());
+        patTTP && childTemplateId && childTemplateId->templateArgumentList) {
+      return deduceTemplateTemplateParameter(patTTP, concSym->type(),
+                                             childTemplateId);
+    }
+
     if (auto patInfo = template_parameter_info(patSym)) {
       return deduceOrCheck(paramPosition(patInfo->depth, patInfo->index),
                            concSym, /*countAsParamMatch=*/true);
@@ -288,8 +394,7 @@ struct PartialSpecMatcher {
       return true;
     }
 
-    return deduceType(patType, concType,
-                      pattern ? pattern->child(patTemplId, argPos) : nullptr);
+    return deduceType(patType, concType, childTemplateId);
   }
 
   auto matchArg(const TemplateArgument& pat, const TemplateArgument& conc,
@@ -298,9 +403,53 @@ struct PartialSpecMatcher {
                           pattern ? pattern->root : nullptr, argPos);
   }
 
+  auto deduceTemplateTemplateParameter(const TemplateTypeParameterType* patTTP,
+                                       const Type* concType,
+                                       SimpleTemplateIdAST* patTemplId)
+      -> bool {
+    auto concClassType = type_cast<ClassType>(concType);
+    if (!concClassType) return false;
+
+    auto concClassSym = concClassType->symbol();
+    if (!concClassSym || !concClassSym->isSpecialization()) return false;
+
+    auto primary = concClassSym->primaryTemplateSymbol();
+    if (!primary || !primary->templateDeclaration()) return false;
+
+    auto pos = paramPosition(patTTP->depth(), patTTP->index());
+    if (!deduceOrCheck(pos, primary, /*countAsParamMatch=*/true)) return false;
+
+    ++templateTemplateBindings;
+
+    auto patSymbols =
+        collectWrittenTemplateArgumentSymbols(patTemplId->templateArgumentList);
+    if (!patSymbols) return false;
+
+    auto concSymbols = toSymbolVector(concClassSym->templateArguments());
+
+    auto patInfo = patSymbols->empty()
+                       ? std::nullopt
+                       : template_parameter_info(patSymbols->back());
+    auto patHasTrailingPack = patInfo && patInfo->isPack;
+    if (!patHasTrailingPack && patSymbols->size() < concSymbols.size()) {
+      if (!hasDefaultsFromPosition(primary->templateDeclaration(),
+                                   patSymbols->size())) {
+        return false;
+      }
+      concSymbols.resize(patSymbols->size());
+    }
+
+    return finishNestedMatch(*patSymbols, concSymbols, patTemplId);
+  }
+
   auto deduceType(const Type* patType, const Type* concType,
                   SimpleTemplateIdAST* patTemplId) -> bool {
     if (!patType || !concType) return false;
+
+    if (auto patTTP = type_cast<TemplateTypeParameterType>(patType);
+        patTTP && patTemplId && patTemplId->templateArgumentList) {
+      return deduceTemplateTemplateParameter(patTTP, concType, patTemplId);
+    }
 
     if (auto patParamInfo = getTypeParamInfo(patType)) {
       auto pos = paramPosition(patParamInfo->depth, patParamInfo->index);
@@ -433,14 +582,8 @@ struct PartialSpecMatcher {
             patClassSym->templateDeclaration()) {
           if (!patTemplId) return false;
 
-          if (!matchNestedWithPattern(patTemplId, patClassSym,
-                                      concClassSym->templateArguments())) {
-            return false;
-          }
-
-          ++score;
-          ++nestedMatches;
-          return true;
+          return matchNestedWithPattern(patTemplId, patClassSym,
+                                        concClassSym->templateArguments());
         }
 
         if (patClassSym->isSpecialization() &&
@@ -451,14 +594,8 @@ struct PartialSpecMatcher {
           if (!primary->templateDeclaration()) return false;
           if (!patTemplId) return false;
 
-          if (!matchNestedWithPattern(patTemplId, primary,
-                                      concClassSym->templateArguments())) {
-            return false;
-          }
-
-          ++score;
-          ++nestedMatches;
-          return true;
+          return matchNestedWithPattern(patTemplId, primary,
+                                        concClassSym->templateArguments());
         }
       }
     }
@@ -563,19 +700,10 @@ struct PartialSpecMatcher {
       auto patInnerArgs = Substitution(unit, primarySym->templateDeclaration(),
                                        patTemplId->templateArgumentList)
                               .templateArguments();
-      patSymbols.reserve(patInnerArgs.size());
-      for (const auto& arg : patInnerArgs) {
-        patSymbols.push_back(asSymbolArgument(arg));
-      }
+      patSymbols = toSymbolVector(patInnerArgs);
     }
 
-    std::vector<Symbol*> concSymbols;
-    concSymbols.reserve(concArgs.size());
-    for (const auto& arg : concArgs) {
-      concSymbols.push_back(asSymbolArgument(arg));
-    }
-
-    return deduceArgumentList(patSymbols, concSymbols, patTemplId, 0);
+    return finishNestedMatch(patSymbols, toSymbolVector(concArgs), patTemplId);
   }
 };
 
@@ -593,6 +721,7 @@ struct Candidate {
   int nestedMatches = 0;
   int nonTypeMatches = 0;
   int deducedParamMatches = 0;
+  int templateTemplateBindings = 0;
 };
 
 auto makeParamPosition(TemplateDeclarationAST* templateDecl)
@@ -772,7 +901,13 @@ auto collectCandidate(TranslationUnit* unit, const SpecEntry& spec,
   if (!checkCollapsedSpecArguments(
           unit, ast_cast<SimpleTemplateIdAST>(specBody->unqualifiedId),
           patternArgs, templateArguments, deducedArgs.toTemplateArguments(),
-          specTemplateDecl, specClass->enclosingNonTemplateParametersScope())) {
+          specTemplateDecl, specClass->parent())) {
+    return std::nullopt;
+  }
+
+  if (!ASTRewriter::checkAssociatedConstraints(
+          unit, specClass, deducedArgs.toTemplateArguments(),
+          specTemplateDecl->depth)) {
     return std::nullopt;
   }
 
@@ -788,7 +923,8 @@ auto collectCandidate(TranslationUnit* unit, const SpecEntry& spec,
       .exactTypeMatches = matcher.exactTypeMatches,
       .nestedMatches = matcher.nestedMatches,
       .nonTypeMatches = matcher.nonTypeMatches,
-      .deducedParamMatches = matcher.deducedParamMatches};
+      .deducedParamMatches = matcher.deducedParamMatches,
+      .templateTemplateBindings = matcher.templateTemplateBindings};
 }
 
 template <typename SpecEntry>
@@ -838,7 +974,13 @@ auto collectVariableCandidate(
   if (pattern && !checkCollapsedSpecArguments(
                      unit, pattern->root, patternArgs, templateArguments,
                      deducedArgs.toTemplateArguments(), specTemplateDecl,
-                     specVar->enclosingNonTemplateParametersScope())) {
+                     specVar->parent())) {
+    return std::nullopt;
+  }
+
+  if (!ASTRewriter::checkAssociatedConstraints(
+          unit, specVar, deducedArgs.toTemplateArguments(),
+          specTemplateDecl->depth)) {
     return std::nullopt;
   }
 
@@ -853,11 +995,14 @@ auto collectVariableCandidate(
       .exactTypeMatches = matcher.exactTypeMatches,
       .nestedMatches = matcher.nestedMatches,
       .nonTypeMatches = matcher.nonTypeMatches,
-      .deducedParamMatches = matcher.deducedParamMatches};
+      .deducedParamMatches = matcher.deducedParamMatches,
+      .templateTemplateBindings = matcher.templateTemplateBindings};
 }
 
 auto isLessSpecific(const Candidate& lhs, const Candidate& rhs) -> bool {
   if (lhs.score != rhs.score) return lhs.score < rhs.score;
+  if (lhs.templateTemplateBindings != rhs.templateTemplateBindings)
+    return lhs.templateTemplateBindings > rhs.templateTemplateBindings;
   if (lhs.exactTypeMatches != rhs.exactTypeMatches)
     return lhs.exactTypeMatches < rhs.exactTypeMatches;
   if (lhs.nestedMatches != rhs.nestedMatches)
@@ -875,6 +1020,7 @@ auto isLessSpecific(const Candidate& lhs, const Candidate& rhs) -> bool {
 
 auto hasEqualSpecificity(const Candidate& lhs, const Candidate& rhs) -> bool {
   return lhs.score == rhs.score &&
+         lhs.templateTemplateBindings == rhs.templateTemplateBindings &&
          lhs.exactTypeMatches == rhs.exactTypeMatches &&
          lhs.nestedMatches == rhs.nestedMatches &&
          lhs.nonTypeMatches == rhs.nonTypeMatches &&
@@ -987,8 +1133,7 @@ auto ASTRewriter::tryPartialSpecialization(
     return cached;
   }
 
-  auto specParentScope =
-      selected.specClass->enclosingNonTemplateParametersScope();
+  auto specParentScope = selected.specClass->parent();
   auto specRewriter = ASTRewriter{unit, specParentScope, selected.deducedArgs};
   specRewriter.depth_ = selected.specTemplateDecl->depth;
   specRewriter.binder().setInstantiatingSymbol(selected.specClass);
@@ -1037,8 +1182,7 @@ auto ASTRewriter::tryPartialSpecialization(
       ast_cast<SimpleDeclarationAST>(specTemplateDecl->declaration);
   if (!simpleDecl) return nullptr;
 
-  auto specParentScope =
-      selected.specVar->enclosingNonTemplateParametersScope();
+  auto specParentScope = selected.specVar->parent();
   auto specRewriter = ASTRewriter{unit, specParentScope, selected.deducedArgs};
   specRewriter.depth_ = selected.specTemplateDecl->depth;
   specRewriter.binder().setInstantiatingSymbol(selected.specVar);

--- a/src/parser/cxx/ast_rewriter_pending_body.cc
+++ b/src/parser/cxx/ast_rewriter_pending_body.cc
@@ -302,8 +302,7 @@ auto ASTRewriter::completePendingBody(FunctionSymbol* func,
 
     auto patternClass = symbol_cast<ClassSymbol>(
         originalDef->symbol->enclosingNonTemplateParametersScope());
-    auto instanceClass =
-        symbol_cast<ClassSymbol>(func->enclosingNonTemplateParametersScope());
+    auto instanceClass = symbol_cast<ClassSymbol>(func->parent());
     if (patternClass && instanceClass) {
       rewriter.remapScopeMembers(patternClass, instanceClass);
     }
@@ -338,16 +337,12 @@ auto ASTRewriter::completePendingBody(FunctionSymbol* func,
   rewriter.binder_.setInstantiatingSymbol(func);
 
   if (auto oldFunc = symbol_cast<FunctionSymbol>(originalDef->symbol)) {
-    auto oldClass = symbol_cast<ClassSymbol>(
-        oldFunc->enclosingNonTemplateParametersScope());
-    auto newClass =
-        symbol_cast<ClassSymbol>(func->enclosingNonTemplateParametersScope());
+    auto oldClass = symbol_cast<ClassSymbol>(oldFunc->parent());
+    auto newClass = symbol_cast<ClassSymbol>(func->parent());
 
     while (oldClass && newClass) {
-      auto oldUp = symbol_cast<ClassSymbol>(
-          oldClass->enclosingNonTemplateParametersScope());
-      auto newUp = symbol_cast<ClassSymbol>(
-          newClass->enclosingNonTemplateParametersScope());
+      auto oldUp = symbol_cast<ClassSymbol>(oldClass->parent());
+      auto newUp = symbol_cast<ClassSymbol>(newClass->parent());
       if (!oldUp || !newUp) break;
       oldClass = oldUp;
       newClass = newUp;

--- a/src/parser/cxx/ast_rewriter_requires.cc
+++ b/src/parser/cxx/ast_rewriter_requires.cc
@@ -21,11 +21,14 @@
 #include <cxx/ast.h>
 #include <cxx/ast_interpreter.h>
 #include <cxx/ast_rewriter.h>
+#include <cxx/control.h>
 #include <cxx/dependent_types.h>
+#include <cxx/names.h>
 #include <cxx/substitution.h>
 #include <cxx/symbols.h>
 #include <cxx/translation_unit.h>
 #include <cxx/type_checker.h>
+#include <cxx/types.h>
 
 namespace cxx {
 auto ASTRewriter::shouldReportCheckErrors() const -> bool {
@@ -51,25 +54,159 @@ void ASTRewriter::typeCheckAndCapture(std::function<void()> checkFn) {
   }
 }
 
-auto ASTRewriter::checkRequiresClause(
-    TranslationUnit* unit, Symbol* symbol, RequiresClauseAST* clause,
+auto ASTRewriter::typeConstraintExpression(
+    TranslationUnit* unit, ConstraintTypeParameterSymbol* parameter)
+    -> ExpressionAST* {
+  if (!parameter) return nullptr;
+  if (auto cached = parameter->constraintExpression()) return cached;
+
+  auto typeConstraint = parameter->typeConstraint();
+  if (!typeConstraint || !typeConstraint->symbol) return nullptr;
+
+  auto arena = unit->arena();
+
+  auto constrainedSpecifier = NamedTypeSpecifierAST::create(arena);
+  constrainedSpecifier->unqualifiedId =
+      NameIdAST::create(arena, name_cast<Identifier>(parameter->name()));
+  constrainedSpecifier->symbol = parameter;
+
+  auto constrainedTypeId = TypeIdAST::create(arena);
+  constrainedTypeId->typeSpecifierList =
+      make_list_node<SpecifierAST>(arena, constrainedSpecifier);
+  constrainedTypeId->type = parameter->type();
+
+  auto constrainedArgument = TypeTemplateArgumentAST::create(arena);
+  constrainedArgument->typeId = constrainedTypeId;
+
+  auto templateId = SimpleTemplateIdAST::create(arena);
+  templateId->identifierLoc = typeConstraint->identifierLoc;
+  templateId->lessLoc = typeConstraint->lessLoc;
+  templateId->greaterLoc = typeConstraint->greaterLoc;
+  templateId->identifier = typeConstraint->identifier;
+  templateId->symbol = typeConstraint->symbol;
+
+  auto out = &templateId->templateArgumentList;
+  *out = make_list_node<TemplateArgumentAST>(arena, constrainedArgument);
+  out = &(*out)->next;
+
+  for (auto argument : ListView{typeConstraint->templateArgumentList}) {
+    *out = make_list_node(arena, argument);
+    out = &(*out)->next;
+  }
+
+  auto idExpression = IdExpressionAST::create(arena);
+  idExpression->nestedNameSpecifier = typeConstraint->nestedNameSpecifier;
+  idExpression->unqualifiedId = templateId;
+  idExpression->symbol = typeConstraint->symbol;
+  idExpression->type = unit->control()->getBoolType();
+  idExpression->valueCategory = ValueCategory::kPrValue;
+
+  parameter->setConstraintExpression(idExpression);
+
+  return idExpression;
+}
+
+auto ASTRewriter::associatedConstraints(TranslationUnit* unit, Symbol* symbol)
+    -> std::vector<ExpressionAST*> {
+  std::vector<ExpressionAST*> constraints;
+
+  auto templateDeclaration = template_declaration_of(symbol);
+
+  for (auto parameter :
+       ListView{templateDeclaration ? templateDeclaration->templateParameterList
+                                    : nullptr}) {
+    auto constrained =
+        symbol_cast<ConstraintTypeParameterSymbol>(parameter->symbol);
+    if (!constrained) continue;
+    if (auto constraint = typeConstraintExpression(unit, constrained))
+      constraints.push_back(constraint);
+  }
+
+  auto append = [&](RequiresClauseAST* clause) {
+    if (clause && clause->expression) constraints.push_back(clause->expression);
+  };
+
+  if (templateDeclaration) append(templateDeclaration->requiresClause);
+
+  if (auto function = symbol_cast<FunctionSymbol>(symbol)) {
+    if (auto declaration = function->declaration())
+      append(declaration->requiresClause);
+  }
+
+  return constraints;
+}
+
+auto ASTRewriter::evaluateAssociatedConstraints(TranslationUnit* unit,
+                                                Symbol* symbol)
+    -> std::optional<bool> {
+  auto constraints = associatedConstraints(unit, symbol);
+  if (constraints.empty()) return true;
+  if (isDependent(unit, symbol->type())) return std::nullopt;
+
+  SilentDiagnosticsClient silent;
+  auto saved = unit->changeDiagnosticsClient(&silent);
+
+  auto interp = ASTInterpreter{unit};
+  std::optional<bool> conjunction = true;
+
+  for (auto constraint : constraints) {
+    if (!constraint->type) {
+      auto typeChecker = TypeChecker{unit};
+      typeChecker.setScope(symbol->enclosingNonTemplateParametersScope());
+      typeChecker.setReportErrors(false);
+      typeChecker.check(constraint);
+    }
+
+    auto value = interp.evaluate(constraint);
+    auto satisfied = value.has_value() ? interp.toBool(*value) : std::nullopt;
+
+    if (!satisfied.has_value()) {
+      conjunction = std::nullopt;
+      continue;
+    }
+
+    if (!*satisfied) {
+      (void)unit->changeDiagnosticsClient(saved);
+      return false;
+    }
+  }
+
+  (void)unit->changeDiagnosticsClient(saved);
+
+  return conjunction;
+}
+
+auto ASTRewriter::checkConstraintExpression(
+    TranslationUnit* unit, Symbol* symbol, ExpressionAST* constraint,
     const std::vector<TemplateArgument>& templateArguments, int depth) -> bool {
-  if (!clause) return true;
+  if (!constraint) return true;
 
   auto parentScope = symbol->enclosingNonTemplateParametersScope();
   auto reqRewriter = ASTRewriter{unit, parentScope, templateArguments};
   reqRewriter.depth_ = depth;
-  auto rewrittenClause = reqRewriter.requiresClause(clause);
-  if (!rewrittenClause || !rewrittenClause->expression) return true;
+  auto rewritten = reqRewriter.expression(constraint);
+  if (!rewritten) return true;
 
-  reqRewriter.check(rewrittenClause->expression);
+  reqRewriter.check(rewritten);
+
+  if (isDependent(unit, rewritten)) return true;
+
   auto interp = ASTInterpreter{unit};
-  auto val = interp.evaluate(rewrittenClause->expression);
-  if (!val.has_value()) return true;
+  auto val = interp.evaluate(rewritten);
+  if (!val.has_value()) return false;
 
   auto boolVal = interp.toBool(*val);
-  if (boolVal.has_value() && !*boolVal) return false;
+  return boolVal.value_or(false);
+}
 
+auto ASTRewriter::checkAssociatedConstraints(
+    TranslationUnit* unit, Symbol* symbol,
+    const std::vector<TemplateArgument>& templateArguments, int depth) -> bool {
+  for (auto constraint : associatedConstraints(unit, symbol)) {
+    if (!checkConstraintExpression(unit, symbol, constraint, templateArguments,
+                                   depth))
+      return false;
+  }
   return true;
 }
 
@@ -89,7 +226,7 @@ auto ASTRewriter::evaluateConcept(
 
   auto templateArguments = std::move(*subst).templateArguments();
 
-  auto parentScope = conceptSymbol->enclosingNonTemplateParametersScope();
+  auto parentScope = conceptSymbol->parent();
 
   SilentDiagnosticsClient silent;
   auto saved = unit->changeDiagnosticsClient(&silent);

--- a/src/parser/cxx/ast_rewriter_specifiers.cc
+++ b/src/parser/cxx/ast_rewriter_specifiers.cc
@@ -719,9 +719,15 @@ auto ASTRewriter::SpecifierVisitor::operator()(NamedTypeSpecifierAST* ast)
 
   copy->symbol = ast->symbol;
 
-  if (symbol_cast<TypeParameterSymbol>(ast->symbol)) {
+  if (symbol_cast<TypeParameterSymbol>(ast->symbol) ||
+      symbol_cast<ConstraintTypeParameterSymbol>(ast->symbol)) {
     if (auto substituted = rewrite.substitutedSymbol(ast->symbol)) {
       copy->symbol = substituted;
+    }
+    if (auto written = rewrite.writtenTypeArgumentSpecifierFor(ast->symbol)) {
+      copy->nestedNameSpecifier = written->nestedNameSpecifier;
+      copy->unqualifiedId = written->unqualifiedId;
+      copy->isTemplateIntroduced = written->isTemplateIntroduced;
     }
   } else if (symbol_cast<TemplateTypeParameterSymbol>(ast->symbol) &&
              !ast_cast<SimpleTemplateIdAST>(ast->unqualifiedId)) {

--- a/src/parser/cxx/binder.cc
+++ b/src/parser/cxx/binder.cc
@@ -85,12 +85,17 @@ void Binder::note(SourceLocation loc, std::string message) {
 }
 
 auto Binder::inTemplate() const -> bool {
-  return inTemplate_ || explicitTemplateHeadDepth_ > 0;
+  return inTemplate_ || explicitTemplateHeadDepth_ > 0 ||
+         retainsEnclosingTemplateLevels_;
 }
 
 void Binder::enterExplicitTemplateHead() { ++explicitTemplateHeadDepth_; }
 
 void Binder::leaveExplicitTemplateHead() { --explicitTemplateHeadDepth_; }
+
+void Binder::setRetainsEnclosingTemplateLevels(bool value) {
+  retainsEnclosingTemplateLevels_ = value;
+}
 
 void Binder::finishAutoReturnType(FunctionSymbol* functionSymbol) {
   if (!functionSymbol) return;
@@ -591,6 +596,73 @@ auto Binder::declareTypeAlias(SourceLocation identifierLoc, TypeIdAST* typeId,
   return symbol;
 }
 
+namespace {
+
+struct TerminalNestedNameSpecifierName {
+  auto operator()(GlobalNestedNameSpecifierAST*) const -> const Identifier* {
+    return nullptr;
+  }
+
+  auto operator()(SimpleNestedNameSpecifierAST* ast) const
+      -> const Identifier* {
+    return ast->identifier;
+  }
+
+  auto operator()(DecltypeNestedNameSpecifierAST*) const -> const Identifier* {
+    return nullptr;
+  }
+
+  auto operator()(TemplateNestedNameSpecifierAST* ast) const
+      -> const Identifier* {
+    return ast->templateId ? ast->templateId->identifier : nullptr;
+  }
+};
+
+}  // namespace
+
+auto Binder::usingDeclaratorNamesConstructor(UsingDeclaratorAST* ast) -> bool {
+  if (!ast->nestedNameSpecifier || ast->typenameLoc) return false;
+  auto terminal =
+      visit(TerminalNestedNameSpecifierName{}, ast->nestedNameSpecifier);
+  if (!terminal) return false;
+  auto nameId = ast_cast<NameIdAST>(ast->unqualifiedId);
+  return nameId && nameId->identifier == terminal;
+}
+
+auto Binder::bindInheritedConstructors(UsingDeclaratorAST* ast) -> bool {
+  auto derived = symbol_cast<ClassSymbol>(scope());
+  if (!derived) return false;
+
+  auto lookupContext =
+      ast->nestedNameSpecifier ? ast->nestedNameSpecifier->symbol : nullptr;
+  auto base = symbol_cast<ClassSymbol>(lookupContext);
+  if (!base) return isDependent(unit_, ast->nestedNameSpecifier);
+  base = base->resolvedDefinition();
+
+  const auto isDirectBase =
+      std::ranges::any_of(derived->baseClasses(), [&](BaseClassSymbol* b) {
+        auto candidate = symbol_cast<ClassSymbol>(b->symbol());
+        return candidate && candidate->resolvedDefinition() == base;
+      });
+
+  if (!isDirectBase) {
+    error(ast->unqualifiedId->firstSourceLocation(),
+          std::format("'{}' is not a direct base class of '{}'",
+                      to_string(base->name()), to_string(derived->name())));
+    return true;
+  }
+
+  auto symbol = control()->newUsingDeclarationSymbol(
+      derived, ast->unqualifiedId->firstSourceLocation());
+  ast->symbol = symbol;
+  symbol->setName(derived->name());
+  symbol->setDeclarator(ast);
+  symbol->setTarget(base->constructorOverloadSet());
+
+  derived->constructorOverloadSet()->addUsingDeclaration(symbol);
+  return true;
+}
+
 void Binder::bind(UsingDeclaratorAST* ast, Symbol* target) {
   auto makeDependentTypeTarget = [&]() -> Symbol* {
     if (!ast->typenameLoc) return nullptr;
@@ -601,6 +673,10 @@ void Binder::bind(UsingDeclaratorAST* ast, Symbol* target) {
         unit_, ast->nestedNameSpecifier, ast->unqualifiedId));
     return alias;
   };
+
+  if (usingDeclaratorNamesConstructor(ast)) {
+    if (bindInheritedConstructors(ast)) return;
+  }
 
   if (ast->nestedNameSpecifier && !ast->nestedNameSpecifier->symbol) {
     if (reportUnresolvedNestedNameSpecifier(ast->nestedNameSpecifier)) return;
@@ -782,11 +858,12 @@ void Binder::bind(TypenameTypeParameterAST* ast, int index, int depth) {
 }
 
 void Binder::bind(ConstraintTypeParameterAST* ast, int index, int depth) {
-  auto symbol =
-      control()->newConstraintTypeParameterSymbol(scope(), ast->identifierLoc);
-  symbol->setIndex(index);
-  symbol->setDepth(depth);
+  const auto isParameterPack = static_cast<bool>(ast->ellipsisLoc);
+  auto symbol = control()->newConstraintTypeParameterSymbol(
+      scope(), ast->identifierLoc, index, depth, isParameterPack);
   symbol->setName(ast->identifier);
+  symbol->setTypeConstraint(ast->typeConstraint);
+  ast->symbol = symbol;
   scope()->addSymbol(symbol);
 }
 
@@ -824,7 +901,8 @@ void Binder::bind(ConceptDefinitionAST* ast) {
   declaringScope()->addSymbol(symbol);
 }
 
-void Binder::bind(DeductionGuideAST* ast) {
+void Binder::bind(DeductionGuideAST* ast,
+                  TemplateDeclarationAST* templateHead) {
   auto templateParameters = currentTemplateParameters();
 
   auto symbol =
@@ -836,6 +914,8 @@ void Binder::bind(DeductionGuideAST* ast) {
   if (ast->explicitSpecifier) {
     symbol->setExplicit(true);
   }
+  symbol->setDeclaration(ast);
+  if (templateHead) symbol->setTemplateDeclaration(templateHead);
   ast->symbol = symbol;
 
   std::vector<const Type*> parameterTypes;
@@ -1151,7 +1231,7 @@ auto Binder::addImplicitThisCapture(ClassSymbol* classSymbol,
   classSymbol->addSymbol(field);
   classSymbol->setCapturedThisField(field);
 
-  const auto& ctors = classSymbol->constructors();
+  const auto& ctors = classSymbol->declaredConstructors();
   if (!ctors.empty()) {
     auto ctorSymbol = ctors.front();
     auto ctorType = type_cast<FunctionType>(ctorSymbol->type());
@@ -1288,7 +1368,7 @@ void Binder::addImplicitCaptures(LambdaExpressionAST* ast,
 
   if (capturedTypes.empty()) return;
 
-  const auto& ctors = classSymbol->constructors();
+  const auto& ctors = classSymbol->declaredConstructors();
   if (!ctors.empty()) {
     auto ctorSymbol = ctors.front();
     auto ctorType = type_cast<FunctionType>(ctorSymbol->type());
@@ -1654,7 +1734,7 @@ void Binder::completeLambdaBody(LambdaExpressionAST* ast) {
     templateDecl->declaration = funcDef;
 
   auto closureName = name_cast<Identifier>(classSymbol->name());
-  for (auto ctor : classSymbol->constructors()) {
+  for (auto ctor : classSymbol->declaredConstructors()) {
     if (ctor->declaration()) continue;
 
     auto ctorNameId = NameIdAST::create(ar, closureName);
@@ -1819,6 +1899,93 @@ auto isEffectivelyUnboundedArray(TranslationUnit* unit, const Type* type)
   return !arrayBoundToString(type).has_value();
 }
 
+auto unqualifiedIdsStructurallyEquivalentForRedeclaration(TranslationUnit* unit,
+                                                          UnqualifiedIdAST* a,
+                                                          UnqualifiedIdAST* b)
+    -> bool {
+  if (a == b) return true;
+  if (!a || !b) return false;
+
+  if (auto aName = ast_cast<NameIdAST>(a)) {
+    auto bName = ast_cast<NameIdAST>(b);
+    return bName && aName->identifier == bName->identifier;
+  }
+
+  auto aTemplateId = ast_cast<SimpleTemplateIdAST>(a);
+  auto bTemplateId = ast_cast<SimpleTemplateIdAST>(b);
+  if (!aTemplateId || !bTemplateId) return false;
+  if (aTemplateId->identifier != bTemplateId->identifier) return false;
+  return areTemplateArgumentListsSyntacticallyEquivalent(
+      unit, aTemplateId->templateArgumentList,
+      bTemplateId->templateArgumentList);
+}
+
+auto nestedNameSpecifiersStructurallyEquivalent(TranslationUnit* unit,
+                                                NestedNameSpecifierAST* a,
+                                                NestedNameSpecifierAST* b)
+    -> bool {
+  if (a == b) return true;
+  if (!a || !b) return false;
+  if (a->symbol && b->symbol) {
+    if (a->symbol == b->symbol) return true;
+    auto aInfo = template_parameter_info(a->symbol);
+    auto bInfo = template_parameter_info(b->symbol);
+    return aInfo && bInfo && aInfo->index == bInfo->index &&
+           aInfo->depth == bInfo->depth && aInfo->isPack == bInfo->isPack;
+  }
+
+  if (ast_cast<GlobalNestedNameSpecifierAST>(a)) {
+    return ast_cast<GlobalNestedNameSpecifierAST>(b) != nullptr;
+  }
+
+  if (auto sa = ast_cast<SimpleNestedNameSpecifierAST>(a)) {
+    auto sb = ast_cast<SimpleNestedNameSpecifierAST>(b);
+    if (!sb || sa->identifier != sb->identifier) return false;
+    return nestedNameSpecifiersStructurallyEquivalent(
+        unit, sa->nestedNameSpecifier, sb->nestedNameSpecifier);
+  }
+
+  if (auto ta = ast_cast<TemplateNestedNameSpecifierAST>(a)) {
+    auto tb = ast_cast<TemplateNestedNameSpecifierAST>(b);
+    if (!tb || !ta->templateId || !tb->templateId) return false;
+    if (ta->templateId->identifier != tb->templateId->identifier) return false;
+    if (!areTemplateArgumentListsSyntacticallyEquivalent(
+            unit, ta->templateId->templateArgumentList,
+            tb->templateId->templateArgumentList)) {
+      return false;
+    }
+    return nestedNameSpecifiersStructurallyEquivalent(
+        unit, ta->nestedNameSpecifier, tb->nestedNameSpecifier);
+  }
+
+  if (auto da = ast_cast<DecltypeNestedNameSpecifierAST>(a)) {
+    auto db = ast_cast<DecltypeNestedNameSpecifierAST>(b);
+    if (!db || !da->decltypeSpecifier || !db->decltypeSpecifier) return false;
+    auto aType = da->decltypeSpecifier->type;
+    auto bType = db->decltypeSpecifier->type;
+    if (!aType || !bType) return false;
+    return unit->typeTraits().is_same(aType, bType);
+  }
+
+  return false;
+}
+
+auto unresolvedNameTypesStructurallyEquivalent(TranslationUnit* unit,
+                                               const UnresolvedNameType* a,
+                                               const UnresolvedNameType* b)
+    -> bool {
+  if (a == b) return true;
+  if (!a || !b) return false;
+  if (!unqualifiedIdsStructurallyEquivalentForRedeclaration(
+          unit, a->unqualifiedId(), b->unqualifiedId())) {
+    return false;
+  }
+  return nestedNameSpecifiersStructurallyEquivalent(
+      unit, a->nestedNameSpecifier(), b->nestedNameSpecifier());
+}
+
+}  // namespace
+
 auto areRedeclarationTypesCompatible(TranslationUnit* unit,
                                      const Type* existingType,
                                      const Type* incomingType) -> bool {
@@ -1832,6 +1999,14 @@ auto areRedeclarationTypesCompatible(TranslationUnit* unit,
   }
 
   if (unit->typeTraits().is_same(existingType, incomingType)) return true;
+
+  auto existingUnresolved = type_cast<UnresolvedNameType>(existingType);
+  auto incomingUnresolved = type_cast<UnresolvedNameType>(incomingType);
+  if (existingUnresolved || incomingUnresolved) {
+    return existingUnresolved && incomingUnresolved &&
+           unresolvedNameTypesStructurallyEquivalent(unit, existingUnresolved,
+                                                     incomingUnresolved);
+  }
 
   if (!unit->typeTraits().is_array(existingType) ||
       !unit->typeTraits().is_array(incomingType)) {
@@ -1856,6 +2031,7 @@ auto areRedeclarationTypesCompatible(TranslationUnit* unit,
   return *existingBound == *incomingBound;
 }
 
+namespace {
 auto preferredRedeclarationType(TranslationUnit* unit, const Type* existingType,
                                 const Type* incomingType) -> const Type* {
   if (!unit || !existingType || !incomingType) return existingType;
@@ -2192,8 +2368,31 @@ auto Binder::declareVariable(DeclaratorAST* declarator, const Decl& decl,
                              bool addSymbolToParentScope) -> VariableSymbol* {
   auto name = decl.getName();
   auto currentScope = declaringScope();
-  auto targetScope =
-      decl.specs.isExtern ? scopeForBlockDecl(currentScope) : currentScope;
+  auto qualifiedScope = decl.getScope();
+  auto qualifiedClass = symbol_cast<ClassSymbol>(qualifiedScope);
+  auto qualifiedNamespace = symbol_cast<NamespaceSymbol>(qualifiedScope);
+
+  ClassSymbol* outOfClassMemberClass = nullptr;
+  FieldSymbol* outOfClassMemberField = nullptr;
+  if (qualifiedClass) {
+    for (auto candidate : qualifiedClass->find(name)) {
+      auto field = symbol_cast<FieldSymbol>(candidate);
+      if (!field || !field->isStatic()) continue;
+      outOfClassMemberClass = qualifiedClass;
+      outOfClassMemberField = field;
+      break;
+    }
+  }
+
+  const bool isOutOfClassStaticMemberDef = outOfClassMemberField != nullptr;
+  const bool isOutOfNamespaceMemberDef = qualifiedNamespace != nullptr;
+
+  auto targetScope = isOutOfClassStaticMemberDef
+                         ? static_cast<ScopeSymbol*>(outOfClassMemberClass)
+                     : isOutOfNamespaceMemberDef
+                         ? static_cast<ScopeSymbol*>(qualifiedNamespace)
+                     : decl.specs.isExtern ? scopeForBlockDecl(currentScope)
+                                           : currentScope;
 
   auto symbol = control()->newVariableSymbol(targetScope, decl.location());
   auto type = getDeclaratorType(unit_, declarator, decl.specs.type());
@@ -2201,64 +2400,41 @@ auto Binder::declareVariable(DeclaratorAST* declarator, const Decl& decl,
   symbol->setName(name);
   symbol->setType(type);
 
-  bool isOutOfClassStaticMemberDef = false;
-  if (auto declId = decl.declaratorId) {
-    if (auto nns = declId->nestedNameSpecifier; nns && nns->symbol) {
-      auto classSymbol = symbol_cast<ClassSymbol>(nns->symbol);
-      if (!classSymbol) {
-        if (auto classType =
-                type_cast<ClassType>(traits.remove_cv(nns->symbol->type()))) {
-          classSymbol = classType->symbol();
-        }
-      }
-      if (classSymbol) {
-        for (auto candidate : classSymbol->find(name)) {
-          auto field = symbol_cast<FieldSymbol>(candidate);
-          if (!field || !field->isStatic()) continue;
-          field->setDefinition(symbol);
-          symbol->setStatic(true);
-          symbol->setParent(classSymbol);
-          isOutOfClassStaticMemberDef = true;
-          break;
-        }
-      }
-    }
+  if (isOutOfClassStaticMemberDef) {
+    outOfClassMemberField->setDefinition(symbol);
+    symbol->setStatic(true);
   }
+
   if (auto classType = type_cast<ClassType>(traits.remove_cv(type))) {
     traits.requireCompleteClass(classType->symbol());
   }
-  if (addSymbolToParentScope) {
-    for (auto candidate : targetScope->find(name)) {
-      if (auto existing = symbol_cast<VariableSymbol>(candidate)) {
-        if (isOutOfClassStaticMemberDef &&
-            (existing->isStatic() ||
-             symbol_cast<ClassSymbol>(existing->parent()))) {
-          break;
-        }
-        if (!areRedeclarationTypesCompatible(unit_, existing->type(),
-                                             symbol->type())) {
-          error(
-              symbol->location(),
+
+  if (!addSymbolToParentScope || isOutOfClassStaticMemberDef) return symbol;
+
+  for (auto candidate : targetScope->find(name)) {
+    if (auto existing = symbol_cast<VariableSymbol>(candidate)) {
+      if (!areRedeclarationTypesCompatible(unit_, existing->type(),
+                                           symbol->type())) {
+        error(symbol->location(),
               std::format("conflicting declaration of '{}'", to_string(name)));
-          continue;
-        }
-
-        auto canon = existing->canonical();
-        auto mergedType =
-            preferredRedeclarationType(unit_, canon->type(), symbol->type());
-        canon->setType(mergedType);
-        symbol->setType(mergedType);
-        canon->addRedeclaration(symbol);
-        break;
+        continue;
       }
-    }
 
-    targetScope->addSymbol(symbol);
-
-    if (targetScope != currentScope) {
-      if (symbol->canonical() == symbol) symbol->setHidden(true);
-      injectUsing(currentScope, name, symbol->canonical(), decl.location());
+      auto canon = existing->canonical();
+      auto mergedType =
+          preferredRedeclarationType(unit_, canon->type(), symbol->type());
+      canon->setType(mergedType);
+      symbol->setType(mergedType);
+      canon->addRedeclaration(symbol);
+      break;
     }
+  }
+
+  targetScope->addSymbol(symbol);
+
+  if (targetScope != currentScope && !isOutOfNamespaceMemberDef) {
+    if (symbol->canonical() == symbol) symbol->setHidden(true);
+    injectUsing(currentScope, name, symbol->canonical(), decl.location());
   }
   return symbol;
 }

--- a/src/parser/cxx/binder.h
+++ b/src/parser/cxx/binder.h
@@ -53,6 +53,11 @@ class TranslationUnit;
     TranslationUnit* unit, List<TemplateArgumentAST*>* a,
     List<TemplateArgumentAST*>* b) -> bool;
 
+[[nodiscard]] auto areRedeclarationTypesCompatible(TranslationUnit* unit,
+                                                   const Type* existingType,
+                                                   const Type* incomingType)
+    -> bool;
+
 class Binder {
  public:
   struct DefaultArgumentInfo {
@@ -112,6 +117,8 @@ class Binder {
   void enterExplicitTemplateHead();
   void leaveExplicitTemplateHead();
 
+  void setRetainsEnclosingTemplateLevels(bool value);
+
   void finishAutoReturnType(FunctionSymbol* functionSymbol);
 
   [[nodiscard]] auto enterBlock(SourceLocation loc) -> BlockSymbol*;
@@ -166,6 +173,10 @@ class Binder {
 
   void synthesizeCompleteObjectCtor(FunctionSymbol* ctor);
 
+  [[nodiscard]] auto inheritedConstructorFor(ClassSymbol* classSymbol,
+                                             FunctionSymbol* baseConstructor)
+      -> FunctionSymbol*;
+
   void synthesizeDefaultedMemberBody(FunctionSymbol* fn);
 
   void bind(DecltypeSpecifierAST* ast);
@@ -177,6 +188,11 @@ class Binder {
             bool inTemplateParameters);
 
   void bind(UsingDeclaratorAST* ast, Symbol* target);
+
+  [[nodiscard]] static auto usingDeclaratorNamesConstructor(
+      UsingDeclaratorAST* ast) -> bool;
+
+  [[nodiscard]] auto bindInheritedConstructors(UsingDeclaratorAST* ast) -> bool;
 
   void bind(BaseSpecifierAST* ast, Symbol* resolvedType = nullptr);
 
@@ -190,7 +206,7 @@ class Binder {
 
   void bind(ConceptDefinitionAST* ast);
 
-  void bind(DeductionGuideAST* ast);
+  void bind(DeductionGuideAST* ast, TemplateDeclarationAST* templateHead);
 
   void bind(LambdaExpressionAST* ast);
 
@@ -330,6 +346,7 @@ class Binder {
   int lambdaCount_ = 0;
   int explicitTemplateHeadDepth_ = 0;
   bool inTemplate_ = false;
+  bool retainsEnclosingTemplateLevels_ = false;
   bool reportErrors_ = true;
   std::unordered_map<FunctionSymbol*, int> lambdaDiscriminators_;
   std::unordered_map<FunctionSymbol*, std::vector<DefaultArgumentInfo>>

--- a/src/parser/cxx/binder_complete_class.cc
+++ b/src/parser/cxx/binder_complete_class.cc
@@ -77,6 +77,10 @@ struct [[nodiscard]] Binder::CompleteClass {
   void addCopyAssignmentOperator();
   void addMoveAssignmentOperator();
   void addDestructor();
+  void addInheritedConstructors();
+  auto declareInheritedConstructor(FunctionSymbol* inherited)
+      -> FunctionSymbol*;
+  void synthesizeInheritedConstructorBody(FunctionSymbol* fn);
 
   void synthesizeStructorVariants();
   auto newStructorVariant(FunctionSymbol* principal) -> FunctionSymbol*;
@@ -109,13 +113,27 @@ void Binder::complete(ClassSpecifierAST* ast) {
   CompleteClass{*this, ast}.complete();
 }
 
+auto Binder::inheritedConstructorFor(ClassSymbol* classSymbol,
+                                     FunctionSymbol* baseConstructor)
+    -> FunctionSymbol* {
+  if (!classSymbol || !baseConstructor) return nullptr;
+  classSymbol = classSymbol->resolvedDefinition();
+
+  CompleteClass completeClass{*this, classSymbol};
+  auto symbol = completeClass.declareInheritedConstructor(baseConstructor);
+  if (!symbol) return nullptr;
+
+  completeClass.synthesizeInheritedConstructorBody(symbol);
+  synthesizeCompleteObjectCtor(symbol);
+  return symbol;
+}
+
 void Binder::synthesizeCompleteObjectCtor(FunctionSymbol* ctor) {
   if (!ctor->isConstructor()) return;
   if (ctor->isDeleted() || ctor->completeObjectVariant()) return;
   if (!type_cast<FunctionType>(ctor->type())) return;
 
-  auto classSymbol =
-      symbol_cast<ClassSymbol>(ctor->enclosingNonTemplateParametersScope());
+  auto classSymbol = symbol_cast<ClassSymbol>(ctor->parent());
   if (!classSymbol) return;
   classSymbol = classSymbol->resolvedDefinition();
 
@@ -131,8 +149,7 @@ void Binder::synthesizeDefaultedMemberBody(FunctionSymbol* fn) {
   auto def = fn->declaration();
   if (!def || !ast_cast<DefaultFunctionBodyAST>(def->functionBody)) return;
 
-  auto classSymbol =
-      symbol_cast<ClassSymbol>(fn->enclosingNonTemplateParametersScope());
+  auto classSymbol = symbol_cast<ClassSymbol>(fn->parent());
   if (!classSymbol) return;
   classSymbol = classSymbol->resolvedDefinition();
   if (classSymbol->isUnion() || classSymbol->isClosureType()) return;
@@ -203,6 +220,118 @@ void Binder::CompleteClass::synthesizeSpecialMembers() {
     addMoveAssignmentOperator();
 
   addDestructor();
+
+  addInheritedConstructors();
+}
+
+void Binder::CompleteClass::addInheritedConstructors() {
+  auto overloadSet = classSymbol->constructorOverloadSet();
+  if (overloadSet->usingDeclarations().empty()) return;
+
+  for (auto inherited : overloadSet->functions()) {
+    if (inherited->templateDeclaration() && !inherited->isSpecialization())
+      continue;
+    (void)declareInheritedConstructor(inherited);
+  }
+}
+
+auto Binder::CompleteClass::declareInheritedConstructor(
+    FunctionSymbol* inherited) -> FunctionSymbol* {
+  auto base = symbol_cast<ClassSymbol>(inherited->parent());
+  if (!base || base->resolvedDefinition() == classSymbol) return nullptr;
+
+  auto inheritedType = type_cast<FunctionType>(inherited->type());
+  if (!inheritedType) return nullptr;
+
+  auto canonical = inherited->canonical();
+  for (auto existing : classSymbol->declaredConstructors()) {
+    if (auto from = existing->inheritedConstructor();
+        from && from->canonical() == canonical)
+      return existing;
+  }
+
+  auto symbol = newDefaultedFunction(classSymbol->name(), inherited->type());
+  symbol->setInheritedConstructor(inherited);
+  symbol->setExplicit(inherited->isExplicit());
+  symbol->setConstexpr(inherited->isConstexpr());
+
+  auto params = control()->newFunctionParametersSymbol(symbol, {});
+  symbol->addSymbol(params);
+
+  std::vector<ParameterSymbol*> sourceParameters;
+  if (auto sourceScope = inherited->functionParameters()) {
+    for (auto source : views::members(sourceScope) | views::parameters)
+      sourceParameters.push_back(source);
+  }
+
+  std::size_t position = 0;
+  for (auto parameterType : inheritedType->parameterTypes()) {
+    auto param = control()->newParameterSymbol(params, symbol->location());
+    param->setType(parameterType);
+    if (position < sourceParameters.size()) {
+      param->setName(sourceParameters[position]->name());
+      param->setDefaultArgument(sourceParameters[position]->defaultArgument());
+    }
+    params->addSymbol(param);
+    ++position;
+  }
+
+  classSymbol->addConstructor(symbol);
+  attachDeclaration(symbol, makeCtorNameId());
+  return symbol;
+}
+
+void Binder::CompleteClass::synthesizeInheritedConstructorBody(
+    FunctionSymbol* fn) {
+  auto def = fn->declaration();
+  if (!def || !ast_cast<DefaultFunctionBodyAST>(def->functionBody)) return;
+
+  auto inherited = fn->inheritedConstructor();
+  auto base = symbol_cast<ClassSymbol>(inherited->parent());
+  if (!base) return;
+  base = base->resolvedDefinition();
+
+  BaseClassSymbol* baseClass = nullptr;
+  for (auto candidate : classSymbol->baseClasses()) {
+    auto candidateClass = symbol_cast<ClassSymbol>(candidate->symbol());
+    if (candidateClass && candidateClass->resolvedDefinition() == base)
+      baseClass = candidate;
+  }
+  if (!baseClass) return;
+
+  auto init = ParenMemInitializerAST::create(pool);
+  if (auto id = name_cast<Identifier>(base->name()))
+    init->unqualifiedId = NameIdAST::create(pool, id);
+  init->symbol = baseClass;
+  init->constructor = inherited;
+
+  List<ExpressionAST*>* args = nullptr;
+  auto argsTail = &args;
+  for (auto param :
+       views::members(fn->functionParameters()) | views::parameters) {
+    auto argExpr = makeParamRef(param);
+    if (!binder.traits.is_reference(param->type())) {
+      auto load = ImplicitCastExpressionAST::create(pool);
+      load->castKind = ImplicitCastKind::kLValueToRValueConversion;
+      load->expression = argExpr;
+      load->type = binder.traits.remove_cv(argExpr->type);
+      load->valueCategory = ValueCategory::kPrValue;
+      argExpr = load;
+    }
+    *argsTail = make_list_node<ExpressionAST>(pool, argExpr);
+    argsTail = &(*argsTail)->next;
+  }
+  init->expressionList = args;
+
+  auto body = CompoundStatementFunctionBodyAST::create(pool);
+  body->memInitializerList = make_list_node<MemInitializerAST>(pool, init);
+  body->statement = CompoundStatementAST::create(pool);
+  def->functionBody = body;
+
+  TypeChecker check{binder.unit_};
+  check.setScope(fn);
+  check.setReportErrors(binder.reportErrors());
+  check.check_mem_initializers(body);
 }
 
 auto Binder::CompleteClass::hasVirtualBaseDestructor() const -> bool {
@@ -335,7 +464,7 @@ auto Binder::CompleteClass::defaultConstructorIsDeleted() const -> bool {
 }
 
 void Binder::CompleteClass::addDefaultConstructor() {
-  if (!classSymbol->constructors().empty()) return;
+  if (!classSymbol->declaredConstructors().empty()) return;
 
   auto symbol = newDefaultedFunction(
       classSymbol->name(),
@@ -520,7 +649,7 @@ void Binder::CompleteClass::synthesizeStructorVariants() {
   const bool hasVirtualBases = !layout->virtualBases().empty();
 
   if (hasVirtualBases) {
-    for (auto ctor : classSymbol->constructors()) {
+    for (auto ctor : classSymbol->declaredConstructors()) {
       if (ctor->completeObjectVariant()) continue;
       if (ctor->isDeleted()) continue;
       if (ctor->templateDeclaration()) continue;
@@ -646,11 +775,7 @@ auto Binder::CompleteClass::pickVBaseConstructor(ClassSymbol* vbase,
     -> FunctionSymbol* {
   if (isCopy) return vbase->copyConstructor();
   if (isMove) return vbase->moveConstructor();
-  for (auto candidate : vbase->constructors()) {
-    auto funcType = type_cast<FunctionType>(candidate->type());
-    if (funcType && funcType->parameterTypes().empty()) return candidate;
-  }
-  return nullptr;
+  return vbase->defaultConstructor();
 }
 
 void Binder::CompleteClass::synthesizeCompleteObjectCtor(FunctionSymbol* ctor) {
@@ -663,14 +788,10 @@ void Binder::CompleteClass::synthesizeCompleteObjectCtor(FunctionSymbol* ctor) {
 
   auto variant = newStructorVariant(ctor);
 
-  std::vector<ParameterSymbol*> params;
-  for (auto member : views::members(variant)) {
-    auto paramsSym = symbol_cast<FunctionParametersSymbol>(member);
-    if (!paramsSym) continue;
-    for (auto param : views::members(paramsSym)) {
-      if (auto p = symbol_cast<ParameterSymbol>(param)) params.push_back(p);
-    }
-  }
+  auto range =
+      views::members(variant->functionParameters()) | views::parameters;
+
+  std::vector params(begin(range), end(range));
 
   if (params.size() == 1) {
     auto paramType = params[0]->type();
@@ -707,6 +828,10 @@ void Binder::CompleteClass::synthesizeCompleteObjectCtor(FunctionSymbol* ctor) {
           isCopy ? control()->getConstType(vbase->type()) : vbase->type();
       cast->valueCategory = ValueCategory::kLValue;
       init->expressionList = make_list_node<ExpressionAST>(pool, cast);
+    } else if (vbaseCtor) {
+      TypeChecker check{binder.unit_};
+      check.setScope(ctor);
+      check.append_default_arguments(vbaseCtor, &init->expressionList);
     }
 
     *memInitsTail = make_list_node<MemInitializerAST>(pool, init);
@@ -854,6 +979,11 @@ void Binder::CompleteClass::synthesizeMemberwiseBodies() {
     auto def = fn->declaration();
     return def && ast_cast<DefaultFunctionBodyAST>(def->functionBody);
   };
+
+  for (auto fn : classSymbol->declaredConstructors()) {
+    if (fn->inheritedConstructor() && needsBody(fn))
+      synthesizeInheritedConstructorBody(fn);
+  }
 
   if (auto fn = classSymbol->copyConstructor(); needsBody(fn))
     synthesizeCopyMoveCtorBody(fn, /*isMove=*/false);

--- a/src/parser/cxx/binder_declare_function.cc
+++ b/src/parser/cxx/binder_declare_function.cc
@@ -40,23 +40,6 @@ namespace cxx {
     List<TemplateArgumentAST*>* b) -> bool;
 
 namespace {
-auto arrayBoundToString(const Type* type) -> std::optional<std::string> {
-  if (auto bounded = type_cast<BoundedArrayType>(type)) {
-    return std::to_string(bounded->size());
-  }
-  return std::nullopt;
-}
-
-auto isEffectivelyUnboundedArray(TranslationUnit* unit, const Type* type)
-    -> bool {
-  if (!unit || !type) return false;
-  if (unit->typeTraits().is_unbounded_array(type)) return true;
-
-  auto unresolved = type_cast<UnresolvedBoundedArrayType>(type);
-  if (!unresolved) return false;
-  return !arrayBoundToString(type).has_value();
-}
-
 namespace {
 [[nodiscard]] auto expressionsStructurallyEquivalent(TranslationUnit* unit,
                                                      ExpressionAST* a,
@@ -477,39 +460,6 @@ auto typesEquivalentModuloOwnHeadDepth(TranslationUnit* unit, const Type* lhs,
   return unit->typeTraits().is_same(lhs, rhs);
 }
 }  // namespace
-
-auto areRedeclarationTypesCompatible(TranslationUnit* unit, const Type* lhs,
-                                     const Type* rhs) -> bool {
-  if (!unit || !lhs || !rhs) return false;
-
-  while (auto qual = type_cast<QualType>(lhs)) {
-    lhs = qual->elementType();
-  }
-  while (auto qual = type_cast<QualType>(rhs)) {
-    rhs = qual->elementType();
-  }
-
-  if (unit->typeTraits().is_same(lhs, rhs)) return true;
-
-  if (!unit->typeTraits().is_array(lhs) || !unit->typeTraits().is_array(rhs))
-    return false;
-
-  auto lhsElement = unit->typeTraits().get_element_type(lhs);
-  auto rhsElement = unit->typeTraits().get_element_type(rhs);
-  if (!areRedeclarationTypesCompatible(unit, lhsElement, rhsElement)) {
-    return false;
-  }
-
-  if (isEffectivelyUnboundedArray(unit, lhs) ||
-      isEffectivelyUnboundedArray(unit, rhs)) {
-    return true;
-  }
-
-  auto lhsBound = arrayBoundToString(lhs);
-  auto rhsBound = arrayBoundToString(rhs);
-  if (!lhsBound || !rhsBound) return true;
-  return *lhsBound == *rhsBound;
-}
 
 auto areFunctionSignaturesEquivalentForRedeclaration(TranslationUnit* unit,
                                                      const Type* lhs,

--- a/src/parser/cxx/binder_resolve_id.cc
+++ b/src/parser/cxx/binder_resolve_id.cc
@@ -207,7 +207,7 @@ auto Binder::ResolveUnqualifiedId::resolveClassTemplateId(
     return cached;
   }
 
-  auto parentScope = classSymbol->enclosingNonTemplateParametersScope();
+  auto parentScope = classSymbol->parent();
   auto spec = control()->newClassSymbol(parentScope, classSymbol->location());
   spec->setName(classSymbol->name());
   spec->setType(control()->getClassType(spec));
@@ -233,9 +233,14 @@ auto Binder::ResolveUnqualifiedId::resolveTypeAliasTemplateId(
     return nullptr;
   }
 
-  return ASTRewriter::instantiate(binder.unit_,
-                                  templateId->templateArgumentList,
-                                  typeAliasSymbol, templateId->identifierLoc);
+  const auto retainEnclosingTemplateLevels =
+      inTemplate() && hasDependentTemplateArguments(binder.unit_, templateId);
+
+  return ASTRewriter::instantiate(
+      binder.unit_, templateId->templateArgumentList, typeAliasSymbol,
+      templateId->identifierLoc, /*sfinaeContext=*/false,
+      /*argsComplete=*/false, /*declarationOnly=*/false,
+      retainEnclosingTemplateLevels);
 }
 
 auto Binder::ResolveUnqualifiedId::operator()(SimpleTemplateIdAST* templateId)
@@ -252,19 +257,19 @@ auto Binder::ResolveUnqualifiedId::operator()(SimpleTemplateIdAST* templateId)
     }
   }
 
-  if (shouldKeepTemplateIdAsDependent(templateId)) return templateId->symbol;
-
   auto resolvedSymbol = templateId->symbol;
   if (auto injected = symbol_cast<InjectedClassNameSymbol>(resolvedSymbol)) {
     resolvedSymbol = injected->classSymbol();
   }
 
-  if (auto classSymbol = symbol_cast<ClassSymbol>(resolvedSymbol)) {
-    return resolveClassTemplateId(templateId, classSymbol);
-  }
-
   if (auto typeAliasSymbol = symbol_cast<TypeAliasSymbol>(resolvedSymbol)) {
     return resolveTypeAliasTemplateId(templateId, typeAliasSymbol);
+  }
+
+  if (shouldKeepTemplateIdAsDependent(templateId)) return templateId->symbol;
+
+  if (auto classSymbol = symbol_cast<ClassSymbol>(resolvedSymbol)) {
+    return resolveClassTemplateId(templateId, classSymbol);
   }
 
   return templateId->symbol;

--- a/src/parser/cxx/binder_structured_bindings.cc
+++ b/src/parser/cxx/binder_structured_bindings.cc
@@ -80,7 +80,7 @@ auto Binder::declareStructuredBindingEntity(
   TypeChecker check{unit_};
   check.setScope(scope());
   check.setReportErrors(unit_->config().checkTypes);
-  check.check_init_declarator(initDeclarator);
+  check.check_init_declarator(initDeclarator, /*typeSpecifier=*/nullptr);
 
   return initDeclarator;
 }

--- a/src/parser/cxx/class_template_deduction.cc
+++ b/src/parser/cxx/class_template_deduction.cc
@@ -1,0 +1,699 @@
+// Copyright (c) 2026 Roberto Raggi <roberto.raggi@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <cxx/ast.h>
+#include <cxx/ast_rewriter.h>
+#include <cxx/class_template_deduction.h>
+#include <cxx/control.h>
+#include <cxx/diagnostics_client.h>
+#include <cxx/names.h>
+#include <cxx/substitution.h>
+#include <cxx/symbols.h>
+#include <cxx/template_argument_deduction.h>
+#include <cxx/translation_unit.h>
+#include <cxx/type_traits.h>
+#include <cxx/types.h>
+#include <cxx/views/symbols.h>
+
+namespace cxx {
+
+namespace {
+
+auto parameterClauseOf(FunctionSymbol* function)
+    -> ParameterDeclarationClauseAST* {
+  auto declaration = function ? function->declaration() : nullptr;
+  if (!declaration || !declaration->declarator) return nullptr;
+  for (auto chunk : ListView{declaration->declarator->declaratorChunkList}) {
+    if (auto functionChunk = ast_cast<FunctionDeclaratorChunkAST>(chunk))
+      return functionChunk->parameterDeclarationClause;
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+ClassTemplateArgumentDeduction::ClassTemplateArgumentDeduction(
+    TranslationUnit* unit)
+    : unit_(unit), control_(unit->control()), arena_(unit->arena()) {}
+
+auto ClassTemplateArgumentDeduction::namesCurrentInstantiation(
+    ClassSymbol* classSymbol, ScopeSymbol* scope) -> bool {
+  auto primary = classSymbol->resolvedDefinition();
+
+  for (auto enclosing = scope; enclosing; enclosing = enclosing->parent()) {
+    auto enclosingClass = symbol_cast<ClassSymbol>(enclosing);
+    if (!enclosingClass) continue;
+
+    auto candidate = enclosingClass->isSpecialization()
+                         ? enclosingClass->primaryTemplateSymbol()
+                         : enclosingClass;
+    if (!candidate) continue;
+    if (candidate->resolvedDefinition() == primary) return true;
+  }
+
+  return false;
+}
+
+auto ClassTemplateArgumentDeduction::placeholderClassTemplate(
+    SpecifierAST* typeSpecifier, ScopeSymbol* scope) -> ClassSymbol* {
+  auto named = ast_cast<NamedTypeSpecifierAST>(typeSpecifier);
+  if (!named) return nullptr;
+  if (!ast_cast<NameIdAST>(named->unqualifiedId)) return nullptr;
+
+  if (symbol_cast<InjectedClassNameSymbol>(named->symbol)) return nullptr;
+
+  auto classSymbol = symbol_cast<ClassSymbol>(named->symbol);
+  if (!classSymbol) return nullptr;
+  if (!classSymbol->templateDeclaration()) return nullptr;
+  if (classSymbol->isSpecialization()) return nullptr;
+
+  if (namesCurrentInstantiation(classSymbol, scope)) return nullptr;
+
+  return classSymbol;
+}
+
+auto ClassTemplateArgumentDeduction::classTemplateParameterCount(
+    ClassSymbol* primaryTemplate) const -> int {
+  int count = 0;
+  for (auto parameter : ListView{classTemplateParameters(primaryTemplate)}) {
+    (void)parameter;
+    ++count;
+  }
+  return count;
+}
+
+auto ClassTemplateArgumentDeduction::classTemplateParameters(
+    ClassSymbol* primaryTemplate) const -> List<TemplateParameterAST*>* {
+  auto templateDeclaration = primaryTemplate->templateDeclaration();
+  if (!templateDeclaration) return nullptr;
+  return templateDeclaration->templateParameterList;
+}
+
+auto ClassTemplateArgumentDeduction::makeGuideTemplateDeclaration(
+    ClassSymbol* primaryTemplate,
+    TemplateDeclarationAST* ownTemplateDeclaration,
+    ParameterDeclarationClauseAST* parameters) -> TemplateDeclarationAST* {
+  auto classParameters = classTemplateParameters(primaryTemplate);
+  auto classTemplateDeclaration = primaryTemplate->templateDeclaration();
+
+  auto templateDeclaration = TemplateDeclarationAST::create(arena_);
+  templateDeclaration->depth = classTemplateDeclaration->depth;
+
+  auto out = &templateDeclaration->templateParameterList;
+  for (auto parameter : ListView{classParameters}) {
+    *out = make_list_node(arena_, parameter);
+    out = &(*out)->next;
+  }
+
+  if (ownTemplateDeclaration) {
+    for (auto parameter :
+         ListView{ownTemplateDeclaration->templateParameterList}) {
+      *out = make_list_node(arena_, parameter);
+      out = &(*out)->next;
+    }
+
+    templateDeclaration->requiresClause =
+        ownTemplateDeclaration->requiresClause;
+  }
+
+  auto declarator = DeclaratorAST::create(arena_);
+  auto chunk = FunctionDeclaratorChunkAST::create(arena_);
+  chunk->parameterDeclarationClause = parameters;
+  declarator->declaratorChunkList =
+      make_list_node<DeclaratorChunkAST>(arena_, chunk);
+
+  auto initDeclarator = InitDeclaratorAST::create(arena_);
+  initDeclarator->declarator = declarator;
+
+  auto declaration = SimpleDeclarationAST::create(arena_);
+  declaration->initDeclaratorList = make_list_node(arena_, initDeclarator);
+
+  templateDeclaration->declaration = declaration;
+
+  return templateDeclaration;
+}
+
+auto ClassTemplateArgumentDeduction::makeInjectedTemplateId(
+    ClassSymbol* primaryTemplate) -> SimpleTemplateIdAST* {
+  auto templateId = SimpleTemplateIdAST::create(arena_);
+  templateId->identifier = name_cast<Identifier>(primaryTemplate->name());
+  templateId->symbol = primaryTemplate;
+
+  auto out = &templateId->templateArgumentList;
+
+  for (auto parameter : ListView{classTemplateParameters(primaryTemplate)}) {
+    auto symbol = parameter->symbol;
+    if (!symbol) return nullptr;
+
+    TemplateArgumentAST* argument = nullptr;
+
+    if (symbol_cast<NonTypeParameterSymbol>(symbol)) {
+      auto id = IdExpressionAST::create(arena_);
+      id->unqualifiedId =
+          NameIdAST::create(arena_, name_cast<Identifier>(symbol->name()));
+      id->symbol = symbol;
+      id->type = symbol->type();
+      id->valueCategory = ValueCategory::kPrValue;
+
+      auto expressionArgument = ExpressionTemplateArgumentAST::create(arena_);
+      expressionArgument->expression = id;
+      argument = expressionArgument;
+    } else {
+      auto typeId = TypeIdAST::create(arena_);
+      typeId->type = symbol->type();
+
+      auto typeArgument = TypeTemplateArgumentAST::create(arena_);
+      typeArgument->typeId = typeId;
+      argument = typeArgument;
+    }
+
+    *out = make_list_node(arena_, argument);
+    out = &(*out)->next;
+  }
+
+  return templateId;
+}
+
+auto ClassTemplateArgumentDeduction::makeParameterDeclaration(
+    const Type* type, SpecifierAST* writtenSpecifier)
+    -> ParameterDeclarationAST* {
+  auto parameter = ParameterDeclarationAST::create(arena_);
+  parameter->type = type;
+  if (writtenSpecifier) {
+    parameter->typeSpecifierList =
+        make_list_node<SpecifierAST>(arena_, writtenSpecifier);
+  }
+  return parameter;
+}
+
+auto ClassTemplateArgumentDeduction::makeParameterClause(
+    const std::vector<ParameterDeclarationAST*>& parameters, bool isVariadic)
+    -> ParameterDeclarationClauseAST* {
+  auto clause = ParameterDeclarationClauseAST::create(arena_);
+  clause->isVariadic = isVariadic;
+
+  auto out = &clause->parameterDeclarationList;
+  for (auto parameter : parameters) {
+    *out = make_list_node(arena_, parameter);
+    out = &(*out)->next;
+  }
+
+  return clause;
+}
+
+void ClassTemplateArgumentDeduction::addConstructorGuide(
+    ClassSymbol* primaryTemplate, FunctionSymbol* constructor,
+    int constructorIndex, ScopeSymbol* scope) {
+  auto constructorType = type_cast<FunctionType>(constructor->type());
+  if (!constructorType) return;
+
+  auto parameters = parameterClauseOf(constructor);
+  if (!parameters) {
+    std::vector<ParameterDeclarationAST*> synthesized;
+    for (auto parameterType : constructorType->parameterTypes())
+      synthesized.push_back(makeParameterDeclaration(parameterType, nullptr));
+    parameters =
+        makeParameterClause(synthesized, constructorType->isVariadic());
+  }
+
+  auto ownTemplateDeclaration = constructor->templateDeclaration();
+
+  auto templateDeclaration = makeGuideTemplateDeclaration(
+      primaryTemplate, ownTemplateDeclaration, parameters);
+
+  auto function = control_->newFunctionSymbol(primaryTemplate->parent(),
+                                              constructor->location());
+  function->setName(primaryTemplate->name());
+  std::vector<const Type*> guideParameterTypes;
+  for (auto parameter : ListView{parameters->parameterDeclarationList})
+    guideParameterTypes.push_back(parameter->type);
+
+  function->setType(control_->getFunctionType(primaryTemplate->type(),
+                                              std::move(guideParameterTypes),
+                                              constructorType->isVariadic()));
+  function->setTemplateDeclaration(templateDeclaration);
+
+  Guide guide;
+  guide.function = function;
+  guide.templateDeclaration = templateDeclaration;
+  guide.parameters = parameters;
+  guide.classParameterCount = classTemplateParameterCount(primaryTemplate);
+  guide.constructorIndex = constructorIndex;
+  guide.isExplicit = constructor->isExplicit();
+  guide.info.fromConstructorTemplate = ownTemplateDeclaration != nullptr;
+  guide.info.fromInheritedConstructor =
+      constructor->inheritedConstructor() != nullptr;
+
+  guides_.push_back(guide);
+}
+
+void ClassTemplateArgumentDeduction::addDefaultConstructorGuide(
+    ClassSymbol* primaryTemplate, ScopeSymbol* scope) {
+  auto parameters = makeParameterClause({}, /*isVariadic=*/false);
+
+  auto templateDeclaration =
+      makeGuideTemplateDeclaration(primaryTemplate, nullptr, parameters);
+
+  auto function = control_->newFunctionSymbol(primaryTemplate->parent(),
+                                              primaryTemplate->location());
+  function->setName(primaryTemplate->name());
+  function->setType(
+      control_->getFunctionType(primaryTemplate->type(), {}, false));
+  function->setTemplateDeclaration(templateDeclaration);
+
+  Guide guide;
+  guide.function = function;
+  guide.templateDeclaration = templateDeclaration;
+  guide.parameters = parameters;
+  guide.classParameterCount = classTemplateParameterCount(primaryTemplate);
+
+  guides_.push_back(guide);
+}
+
+void ClassTemplateArgumentDeduction::addCopyDeductionCandidate(
+    ClassSymbol* primaryTemplate, ScopeSymbol* scope) {
+  auto templateId = makeInjectedTemplateId(primaryTemplate);
+  if (!templateId) return;
+
+  auto specifier = NamedTypeSpecifierAST::create(arena_);
+  specifier->unqualifiedId = templateId;
+  specifier->symbol = primaryTemplate;
+
+  auto parameter = makeParameterDeclaration(primaryTemplate->type(), specifier);
+
+  auto parameters = makeParameterClause({parameter}, /*isVariadic=*/false);
+
+  auto templateDeclaration =
+      makeGuideTemplateDeclaration(primaryTemplate, nullptr, parameters);
+
+  auto function = control_->newFunctionSymbol(primaryTemplate->parent(),
+                                              primaryTemplate->location());
+  function->setName(primaryTemplate->name());
+  function->setType(control_->getFunctionType(
+      primaryTemplate->type(), {primaryTemplate->type()}, false));
+  function->setTemplateDeclaration(templateDeclaration);
+
+  Guide guide;
+  guide.function = function;
+  guide.templateDeclaration = templateDeclaration;
+  guide.parameters = parameters;
+  guide.classParameterCount = classTemplateParameterCount(primaryTemplate);
+  guide.info.isCopyDeductionCandidate = true;
+
+  guides_.push_back(guide);
+}
+
+auto ClassTemplateArgumentDeduction::aggregateElementTypes(
+    ClassSymbol* classSymbol, std::size_t argumentCount)
+    -> std::vector<const Type*> {
+  std::vector<const Type*> elements;
+
+  for (auto base : classSymbol->baseClasses()) {
+    auto baseClass = symbol_cast<ClassSymbol>(base->symbol());
+    if (!baseClass) return {};
+    elements.push_back(baseClass->type());
+  }
+
+  for (auto field : views::members(classSymbol) | views::non_static_fields) {
+    elements.push_back(field->type());
+  }
+
+  if (elements.size() < argumentCount) return {};
+
+  elements.resize(argumentCount);
+
+  return elements;
+}
+
+void ClassTemplateArgumentDeduction::addAggregateDeductionCandidate(
+    ClassSymbol* primaryTemplate, const Initializer& init, ScopeSymbol* scope) {
+  if (init.arguments.empty()) return;
+  if (!primaryTemplate->deductionGuides().empty()) return;
+  if (!TypeTraits{unit_}.is_aggregate(primaryTemplate->type())) return;
+
+  auto elementTypes =
+      aggregateElementTypes(primaryTemplate, init.arguments.size());
+  if (elementTypes.empty()) return;
+
+  std::vector<ParameterDeclarationAST*> parameterDeclarations;
+  for (auto elementType : elementTypes)
+    parameterDeclarations.push_back(
+        makeParameterDeclaration(elementType, nullptr));
+
+  auto parameters =
+      makeParameterClause(parameterDeclarations, /*isVariadic=*/false);
+
+  auto templateDeclaration =
+      makeGuideTemplateDeclaration(primaryTemplate, nullptr, parameters);
+
+  auto function = control_->newFunctionSymbol(primaryTemplate->parent(),
+                                              primaryTemplate->location());
+  function->setName(primaryTemplate->name());
+  function->setType(
+      control_->getFunctionType(primaryTemplate->type(), elementTypes, false));
+  function->setTemplateDeclaration(templateDeclaration);
+
+  Guide guide;
+  guide.function = function;
+  guide.templateDeclaration = templateDeclaration;
+  guide.parameters = parameters;
+  guide.isAggregate = true;
+  guide.classParameterCount = classTemplateParameterCount(primaryTemplate);
+
+  guides_.push_back(guide);
+}
+
+void ClassTemplateArgumentDeduction::addWrittenGuide(
+    ClassSymbol* primaryTemplate, DeductionGuideSymbol* guideSymbol) {
+  auto declaration = guideSymbol->declaration();
+  if (!declaration) return;
+
+  auto guideType = type_cast<FunctionType>(guideSymbol->type());
+  if (!guideType) return;
+
+  auto parameters = declaration->parameterDeclarationClause;
+  if (!parameters) parameters = makeParameterClause({}, /*isVariadic=*/false);
+
+  auto templateDeclaration = TemplateDeclarationAST::create(arena_);
+  if (auto ownTemplateParameters = guideSymbol->templateParameters()) {
+    if (auto ownTemplateDeclaration = guideSymbol->templateDeclaration()) {
+      templateDeclaration->templateParameterList =
+          ownTemplateDeclaration->templateParameterList;
+      templateDeclaration->requiresClause =
+          ownTemplateDeclaration->requiresClause;
+      templateDeclaration->depth = ownTemplateDeclaration->depth;
+    }
+    (void)ownTemplateParameters;
+  }
+
+  auto declarator = DeclaratorAST::create(arena_);
+  auto chunk = FunctionDeclaratorChunkAST::create(arena_);
+  chunk->parameterDeclarationClause = parameters;
+  declarator->declaratorChunkList =
+      make_list_node<DeclaratorChunkAST>(arena_, chunk);
+
+  auto initDeclarator = InitDeclaratorAST::create(arena_);
+  initDeclarator->declarator = declarator;
+
+  auto simpleDeclaration = SimpleDeclarationAST::create(arena_);
+  simpleDeclaration->initDeclaratorList =
+      make_list_node(arena_, initDeclarator);
+  templateDeclaration->declaration = simpleDeclaration;
+
+  auto function = control_->newFunctionSymbol(primaryTemplate->parent(),
+                                              guideSymbol->location());
+  function->setName(primaryTemplate->name());
+  function->setType(guideType);
+  function->setTemplateDeclaration(templateDeclaration);
+
+  Guide guide;
+  guide.function = function;
+  guide.templateDeclaration = templateDeclaration;
+  guide.parameters = parameters;
+  guide.returnTemplateId = declaration->templateId;
+  guide.isExplicit = guideSymbol->isExplicit();
+  guide.info.fromDeductionGuide = true;
+
+  guides_.push_back(guide);
+}
+
+void ClassTemplateArgumentDeduction::collectGuides(ClassSymbol* primaryTemplate,
+                                                   const Initializer& init,
+                                                   ScopeSymbol* scope) {
+  auto definition = primaryTemplate->resolvedDefinition();
+
+  bool hasConstructors = false;
+
+  if (definition->isComplete()) {
+    int constructorIndex = -1;
+    for (auto constructor : definition->constructors()) {
+      ++constructorIndex;
+      hasConstructors = true;
+      addConstructorGuide(primaryTemplate, constructor, constructorIndex,
+                          scope);
+    }
+  }
+
+  if (!hasConstructors) addDefaultConstructorGuide(primaryTemplate, scope);
+
+  addCopyDeductionCandidate(primaryTemplate, scope);
+
+  for (auto guideSymbol : primaryTemplate->deductionGuides())
+    addWrittenGuide(primaryTemplate, guideSymbol);
+
+  if (definition->isComplete())
+    addAggregateDeductionCandidate(definition, init, scope);
+}
+
+auto ClassTemplateArgumentDeduction::guideParameterTypes(
+    ClassSymbol* primaryTemplate, const Guide& guide,
+    List<TemplateArgumentAST*>* deducedArgs, const Initializer& initializer,
+    SourceLocation location, ScopeSymbol* scope)
+    -> std::optional<std::vector<const Type*>> {
+  if (guide.returnTemplateId) {
+    auto substitution =
+        Substitution::make(unit_, guide.templateDeclaration, deducedArgs);
+    if (!substitution) return std::nullopt;
+
+    return ASTRewriter::substituteParameterTypes(
+        unit_, guide.parameters, std::move(*substitution).templateArguments(),
+        guide.templateDeclaration->depth, scope);
+  }
+
+  auto specialization =
+      specializationFor(primaryTemplate, guide, deducedArgs, location, scope);
+  if (!specialization) return std::nullopt;
+
+  if (guide.isAggregate) {
+    auto elements =
+        aggregateElementTypes(specialization, initializer.arguments.size());
+    if (elements.empty()) return std::nullopt;
+    return elements;
+  }
+
+  if (guide.info.isCopyDeductionCandidate)
+    return std::vector<const Type*>{specialization->type()};
+
+  if (guide.constructorIndex < 0) return std::vector<const Type*>{};
+
+  auto constructors = specialization->constructors();
+  if (guide.constructorIndex >= static_cast<int>(constructors.size()))
+    return std::nullopt;
+
+  auto constructor = constructors[guide.constructorIndex];
+
+  if (constructor->templateDeclaration()) {
+    List<TemplateArgumentAST*>* ownArgs = nullptr;
+    auto out = &ownArgs;
+    int skipped = 0;
+    for (auto argument : ListView{deducedArgs}) {
+      if (skipped++ < guide.classParameterCount) continue;
+      *out = make_list_node(arena_, argument);
+      out = &(*out)->next;
+    }
+
+    auto instantiated = ASTRewriter::instantiateForArgs(
+        unit_, ownArgs, constructor, location, /*argsComplete=*/true,
+        /*declarationOnly=*/true);
+    if (!instantiated) return std::nullopt;
+    constructor = instantiated;
+  }
+
+  auto constructorType = type_cast<FunctionType>(constructor->type());
+  if (!constructorType) return std::nullopt;
+
+  return std::vector<const Type*>(constructorType->parameterTypes().begin(),
+                                  constructorType->parameterTypes().end());
+}
+
+auto ClassTemplateArgumentDeduction::requiredParameterCount(
+    const Guide& guide, std::size_t parameterCount) const -> std::size_t {
+  std::size_t required = 0;
+  for (auto parameter :
+       ListView{guide.parameters ? guide.parameters->parameterDeclarationList
+                                 : nullptr}) {
+    if (parameter->expression) break;
+    if (parameter->isPack) break;
+    ++required;
+  }
+  return std::min(required, parameterCount);
+}
+
+auto ClassTemplateArgumentDeduction::argumentList(const Initializer& init)
+    -> List<ExpressionAST*>* {
+  List<ExpressionAST*>* args = nullptr;
+  auto out = &args;
+  for (auto argument : init.arguments) {
+    *out = make_list_node(arena_, argument);
+    out = &(*out)->next;
+  }
+  return args;
+}
+
+auto ClassTemplateArgumentDeduction::specializationFor(
+    ClassSymbol* primaryTemplate, const Guide& guide,
+    List<TemplateArgumentAST*>* deducedArgs, SourceLocation location,
+    ScopeSymbol* scope) -> ClassSymbol* {
+  List<TemplateArgumentAST*>* classArgs = nullptr;
+
+  if (guide.returnTemplateId) {
+    auto substitution =
+        Substitution::make(unit_, guide.templateDeclaration, deducedArgs);
+    if (!substitution) return nullptr;
+
+    auto typeId = TypeIdAST::create(arena_);
+    auto specifier = NamedTypeSpecifierAST::create(arena_);
+    specifier->unqualifiedId = guide.returnTemplateId;
+    specifier->symbol = guide.returnTemplateId->symbol;
+    typeId->typeSpecifierList = make_list_node<SpecifierAST>(arena_, specifier);
+
+    auto substituted = ASTRewriter::substituteDefaultTypeId(
+        unit_, typeId, std::move(*substitution).templateArguments(),
+        guide.templateDeclaration->depth, scope);
+
+    if (!substituted || !substituted->type) return nullptr;
+
+    auto deducedClassType = type_cast<ClassType>(substituted->type);
+    if (!deducedClassType) return nullptr;
+
+    return deducedClassType->symbol();
+  }
+
+  auto out = &classArgs;
+  int remaining = guide.classParameterCount;
+  for (auto argument : ListView{deducedArgs}) {
+    if (remaining-- <= 0) break;
+    *out = make_list_node(arena_, argument);
+    out = &(*out)->next;
+  }
+
+  auto specialization =
+      ASTRewriter::instantiate(unit_, classArgs, primaryTemplate, location);
+
+  return symbol_cast<ClassSymbol>(specialization);
+}
+
+auto ClassTemplateArgumentDeduction::deduce(ClassSymbol* primaryTemplate,
+                                            const Initializer& initializer,
+                                            SourceLocation location,
+                                            ScopeSymbol* scope)
+    -> ClassSymbol* {
+  if (!primaryTemplate || !primaryTemplate->templateDeclaration())
+    return nullptr;
+
+  guides_.clear();
+
+  collectGuides(primaryTemplate, initializer, scope);
+  if (guides_.empty()) return nullptr;
+
+  auto args = argumentList(initializer);
+
+  OverloadResolution overloadResolution{unit_};
+
+  std::vector<Candidate> candidates;
+  candidates.reserve(guides_.size());
+  std::vector<const Guide*> candidateGuides;
+  candidateGuides.reserve(guides_.size());
+  bool explicitGuideRejected = false;
+
+  SilentDiagnosticsClient silent;
+
+  for (const auto& guide : guides_) {
+    auto guideType = type_cast<FunctionType>(guide.function->type());
+    if (!guideType) continue;
+
+    auto saved = unit_->changeDiagnosticsClient(&silent);
+
+    TemplateArgumentDeduction deduction{unit_};
+    auto deduced = deduction.deduceForGuide(guide.templateDeclaration,
+                                            guideType, guide.parameters, args);
+
+    (void)unit_->changeDiagnosticsClient(saved);
+
+    if (!deduced) continue;
+
+    auto substituted = guideParameterTypes(primaryTemplate, guide, *deduced,
+                                           initializer, location, scope);
+    if (!substituted) continue;
+    auto parameterTypes = std::move(*substituted);
+
+    if (parameterTypes.size() < initializer.arguments.size() &&
+        !guideType->isVariadic())
+      continue;
+
+    if (initializer.arguments.size() <
+        requiredParameterCount(guide, parameterTypes.size()))
+      continue;
+
+    if (guide.isExplicit && initializer.isCopyInitialization) {
+      explicitGuideRejected = true;
+      continue;
+    }
+
+    Candidate candidate;
+    candidate.symbol = guide.function;
+    candidate.viable = true;
+    candidate.fromTemplate = true;
+    candidate.deducedTemplateArgs = *deduced;
+    candidate.deduction = guide.info;
+
+    std::size_t index = 0;
+    bool viable = true;
+
+    for (auto argument : initializer.arguments) {
+      if (index >= parameterTypes.size()) {
+        viable = guideType->isVariadic();
+        break;
+      }
+
+      auto sequence = overloadResolution.computeImplicitConversionSequence(
+          argument, parameterTypes[index]);
+
+      if (sequence.rank == ConversionRank::kNone) {
+        viable = false;
+        break;
+      }
+
+      candidate.conversions.push_back(sequence);
+      ++index;
+    }
+
+    if (!viable) continue;
+
+    candidates.push_back(std::move(candidate));
+    candidateGuides.push_back(&guide);
+  }
+
+  if (candidates.empty()) {
+    if (explicitGuideRejected) explicitOnly_ = true;
+    return nullptr;
+  }
+
+  auto result = overloadResolution.selectBestViableFunction(candidates);
+  if (!result.best || result.ambiguous) return nullptr;
+
+  auto winnerIndex = static_cast<std::size_t>(result.best - candidates.data());
+  if (winnerIndex >= candidateGuides.size()) return nullptr;
+
+  return specializationFor(primaryTemplate, *candidateGuides[winnerIndex],
+                           result.best->deducedTemplateArgs, location, scope);
+}
+
+}  // namespace cxx

--- a/src/parser/cxx/class_template_deduction.h
+++ b/src/parser/cxx/class_template_deduction.h
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Roberto Raggi <roberto.raggi@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <cxx/ast_fwd.h>
+#include <cxx/overload_resolution.h>
+#include <cxx/source_location.h>
+#include <cxx/symbols_fwd.h>
+#include <cxx/types_fwd.h>
+
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+namespace cxx {
+class Arena;
+class Control;
+class TranslationUnit;
+
+class ClassTemplateArgumentDeduction {
+ public:
+  explicit ClassTemplateArgumentDeduction(TranslationUnit* unit);
+
+  struct Initializer {
+    std::vector<ExpressionAST*> arguments;
+    bool isListInitialization = false;
+    bool isCopyInitialization = false;
+  };
+
+  [[nodiscard]] static auto placeholderClassTemplate(
+      SpecifierAST* typeSpecifier, ScopeSymbol* scope) -> ClassSymbol*;
+
+  [[nodiscard]] auto deduce(ClassSymbol* primaryTemplate,
+                            const Initializer& initializer,
+                            SourceLocation location, ScopeSymbol* scope)
+      -> ClassSymbol*;
+
+  [[nodiscard]] auto selectedExplicitOnly() const -> bool {
+    return explicitOnly_;
+  }
+
+ private:
+  struct Guide {
+    FunctionSymbol* function = nullptr;
+    TemplateDeclarationAST* templateDeclaration = nullptr;
+    ParameterDeclarationClauseAST* parameters = nullptr;
+    SimpleTemplateIdAST* returnTemplateId = nullptr;
+    int classParameterCount = 0;
+    int constructorIndex = -1;
+    bool isExplicit = false;
+    bool isAggregate = false;
+    DeductionCandidateInfo info;
+  };
+
+  [[nodiscard]] static auto namesCurrentInstantiation(ClassSymbol* classSymbol,
+                                                      ScopeSymbol* scope)
+      -> bool;
+
+  void collectGuides(ClassSymbol* primaryTemplate, const Initializer& init,
+                     ScopeSymbol* scope);
+
+  void addConstructorGuide(ClassSymbol* primaryTemplate,
+                           FunctionSymbol* constructor, int constructorIndex,
+                           ScopeSymbol* scope);
+
+  void addDefaultConstructorGuide(ClassSymbol* primaryTemplate,
+                                  ScopeSymbol* scope);
+
+  void addCopyDeductionCandidate(ClassSymbol* primaryTemplate,
+                                 ScopeSymbol* scope);
+
+  void addAggregateDeductionCandidate(ClassSymbol* primaryTemplate,
+                                      const Initializer& init,
+                                      ScopeSymbol* scope);
+
+  void addWrittenGuide(ClassSymbol* primaryTemplate,
+                       DeductionGuideSymbol* guide);
+
+  [[nodiscard]] auto classTemplateParameters(ClassSymbol* primaryTemplate) const
+      -> List<TemplateParameterAST*>*;
+
+  [[nodiscard]] auto classTemplateParameterCount(
+      ClassSymbol* primaryTemplate) const -> int;
+
+  [[nodiscard]] auto makeGuideTemplateDeclaration(
+      ClassSymbol* primaryTemplate,
+      TemplateDeclarationAST* ownTemplateDeclaration,
+      ParameterDeclarationClauseAST* parameters) -> TemplateDeclarationAST*;
+
+  [[nodiscard]] auto makeInjectedTemplateId(ClassSymbol* primaryTemplate)
+      -> SimpleTemplateIdAST*;
+
+  [[nodiscard]] auto makeParameterDeclaration(const Type* type,
+                                              SpecifierAST* writtenSpecifier)
+      -> ParameterDeclarationAST*;
+
+  [[nodiscard]] auto makeParameterClause(
+      const std::vector<ParameterDeclarationAST*>& parameters, bool isVariadic)
+      -> ParameterDeclarationClauseAST*;
+
+  [[nodiscard]] auto aggregateElementTypes(ClassSymbol* classSymbol,
+                                           std::size_t argumentCount)
+      -> std::vector<const Type*>;
+
+  [[nodiscard]] auto guideParameterTypes(
+      ClassSymbol* primaryTemplate, const Guide& guide,
+      List<TemplateArgumentAST*>* deducedArgs, const Initializer& initializer,
+      SourceLocation location, ScopeSymbol* scope)
+      -> std::optional<std::vector<const Type*>>;
+
+  [[nodiscard]] auto requiredParameterCount(const Guide& guide,
+                                            std::size_t parameterCount) const
+      -> std::size_t;
+
+  [[nodiscard]] auto argumentList(const Initializer& init)
+      -> List<ExpressionAST*>*;
+
+  [[nodiscard]] auto specializationFor(ClassSymbol* primaryTemplate,
+                                       const Guide& guide,
+                                       List<TemplateArgumentAST*>* deducedArgs,
+                                       SourceLocation location,
+                                       ScopeSymbol* scope) -> ClassSymbol*;
+
+  TranslationUnit* unit_;
+  Control* control_;
+  Arena* arena_;
+  std::vector<Guide> guides_;
+  bool explicitOnly_ = false;
+};
+}  // namespace cxx

--- a/src/parser/cxx/control.cc
+++ b/src/parser/cxx/control.cc
@@ -775,10 +775,15 @@ auto Control::newNonTypeParameterSymbol(ScopeSymbol* enclosingScope,
 }
 
 auto Control::newConstraintTypeParameterSymbol(ScopeSymbol* enclosingScope,
-                                               SourceLocation loc)
+                                               SourceLocation loc, int index,
+                                               int depth, bool isParameterPack)
     -> ConstraintTypeParameterSymbol* {
   auto symbol =
       &d->constraintTypeParameterSymbols.emplace_front(enclosingScope);
+  symbol->setIndex(index);
+  symbol->setDepth(depth);
+  symbol->setParameterPack(isParameterPack);
+  symbol->setType(getTypeParameterType(index, depth, isParameterPack));
   symbol->setLocation(loc);
   return symbol;
 }

--- a/src/parser/cxx/control.h
+++ b/src/parser/cxx/control.h
@@ -248,8 +248,8 @@ class Control {
       int depth, bool isPack, std::vector<const Type*> parameters)
       -> TemplateTypeParameterSymbol*;
   [[nodiscard]] auto newConstraintTypeParameterSymbol(
-      ScopeSymbol* enclosingScope, SourceLocation sourceLocation)
-      -> ConstraintTypeParameterSymbol*;
+      ScopeSymbol* enclosingScope, SourceLocation sourceLocation, int index,
+      int depth, bool isParameterPack) -> ConstraintTypeParameterSymbol*;
   [[nodiscard]] auto newEnumeratorSymbol(ScopeSymbol* enclosingScope,
                                          SourceLocation sourceLocation)
       -> EnumeratorSymbol*;

--- a/src/parser/cxx/dependent_types.cc
+++ b/src/parser/cxx/dependent_types.cc
@@ -76,7 +76,7 @@ struct IsDependent {
             tp && !tp->isExplicitTemplateSpecialization())
           return true;
       } else if (auto lambda = symbol_cast<LambdaSymbol>(scope)) {
-        if (lambda->isTemplate()) return true;
+        if (lambda->isTemplate() || lambda->isInTemplate()) return true;
       }
     }
     return false;
@@ -205,6 +205,10 @@ struct IsDependent {
 
   auto operator()(const ClassType* type) -> bool {
     auto sym = type->symbol();
+
+    if (auto ownParameters = sym->templateParameters();
+        ownParameters && !ownParameters->members().empty())
+      return true;
 
     if (sym->templateDeclaration() && !sym->primaryTemplateSymbol())
       return true;
@@ -1009,6 +1013,11 @@ auto isEnclosedInDependentTemplate(TranslationUnit* unit, ScopeSymbol* scope,
                                    bool stopAtConcreteSpecialization) -> bool {
   return IsDependent{unit}.enclosedInDependentTemplate(
       scope, stopAtConcreteSpecialization);
+}
+
+auto isEnclosedInTemplate(ScopeSymbol* scope) -> bool {
+  return IsDependent{nullptr}.enclosedInDependentTemplate(
+      scope, /*stopAtConcreteSpecialization=*/false);
 }
 
 auto isDependentTypeParameterSymbol(Symbol* symbol) -> bool {

--- a/src/parser/cxx/external_name_encoder.cc
+++ b/src/parser/cxx/external_name_encoder.cc
@@ -36,7 +36,7 @@ namespace cxx {
 namespace {
 [[nodiscard]] auto enclosing_class_or_namespace(Symbol* symbol) -> Symbol* {
   if (!symbol) return nullptr;
-  auto parent = symbol->enclosingNonTemplateParametersScope();
+  auto parent = symbol->parent();
   if (!parent || !parent->isClassOrNamespace()) return nullptr;
   return parent;
 }

--- a/src/parser/cxx/implicit_conversion_sequence.h
+++ b/src/parser/cxx/implicit_conversion_sequence.h
@@ -61,6 +61,7 @@ struct ImplicitConversionSequence {
   bool fromSingleElementList = false;
   bool bindsToRvalueRef = false;
   bool bindsToReference = false;
+  bool bindsUnqualifiedImplicitObjectParameter = false;
   bool hasQualificationConversion = false;
   CvQualifiers referenceCv = CvQualifiers::kNone;
 
@@ -78,7 +79,9 @@ struct ImplicitConversionSequence {
         return rank > other.rank;
       }
 
-      if (bindsToRvalueRef != other.bindsToRvalueRef) {
+      if (bindsToRvalueRef != other.bindsToRvalueRef &&
+          !bindsUnqualifiedImplicitObjectParameter &&
+          !other.bindsUnqualifiedImplicitObjectParameter) {
         return bindsToRvalueRef;
       }
 

--- a/src/parser/cxx/lambda_captures.h
+++ b/src/parser/cxx/lambda_captures.h
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2026 Roberto Raggi <roberto.raggi@gmail.com>
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,34 +20,35 @@
 
 #pragma once
 
-#include <cxx/symbols_fwd.h>
-#include <cxx/token_fwd.h>
-#include <cxx/types_fwd.h>
-
-#include <functional>
-#include <variant>
+#include <cxx/ast.h>
 
 namespace cxx {
 
-class Parser;
+[[nodiscard]] inline auto capture_initializer(LambdaCaptureAST* capture)
+    -> ExpressionAST* {
+  if (auto simple = ast_cast<SimpleLambdaCaptureAST>(capture))
+    return simple->initializer;
+  if (auto ref = ast_cast<RefLambdaCaptureAST>(capture))
+    return ref->initializer;
+  if (auto self = ast_cast<ThisLambdaCaptureAST>(capture))
+    return self->initializer;
+  if (auto initCapture = ast_cast<InitLambdaCaptureAST>(capture))
+    return initCapture->initializer;
+  if (auto refInitCapture = ast_cast<RefInitLambdaCaptureAST>(capture))
+    return refInitCapture->initializer;
+  return nullptr;
+}
 
-struct UnqualifiedCompletionContext {
-  ScopeSymbol* scope = nullptr;
-};
-
-struct MemberCompletionContext {
-  const Type* objectType = nullptr;
-  TokenKind accessOp = TokenKind::T_DOT;
-};
-
-using CodeCompletionContext =
-    std::variant<UnqualifiedCompletionContext, MemberCompletionContext>;
-
-struct ParserConfiguration {
-  bool checkTypes = false;
-  bool allowUnprototypedFunctions = false;
-  std::function<bool()> stopParsingPredicate;
-  std::function<void(const CodeCompletionContext&)> complete;
-};
+[[nodiscard]] inline auto is_pack_capture(LambdaCaptureAST* capture) -> bool {
+  if (auto simple = ast_cast<SimpleLambdaCaptureAST>(capture))
+    return bool(simple->ellipsisLoc);
+  if (auto ref = ast_cast<RefLambdaCaptureAST>(capture))
+    return bool(ref->ellipsisLoc);
+  if (auto initCapture = ast_cast<InitLambdaCaptureAST>(capture))
+    return bool(initCapture->ellipsisLoc);
+  if (auto refInitCapture = ast_cast<RefInitLambdaCaptureAST>(capture))
+    return bool(refInitCapture->ellipsisLoc);
+  return false;
+}
 
 }  // namespace cxx

--- a/src/parser/cxx/overload_resolution.cc
+++ b/src/parser/cxx/overload_resolution.cc
@@ -20,6 +20,7 @@
 
 #include <cxx/ast.h>
 #include <cxx/ast_rewriter.h>
+#include <cxx/binder.h>
 #include <cxx/control.h>
 #include <cxx/literals.h>
 #include <cxx/name_lookup.h>
@@ -33,6 +34,7 @@
 #include <cxx/views/symbols.h>
 
 #include <algorithm>
+#include <format>
 
 namespace cxx {
 namespace {
@@ -491,9 +493,80 @@ auto OverloadResolution::initializerListElementType(const Type* targetType)
   return stdconv_.initializerListElementType(targetType);
 }
 
+auto OverloadResolution::implicitObjectArgumentConversion(
+    FunctionSymbol* function, const ImplicitObjectArgument& object)
+    -> std::expected<ImplicitConversionSequence, std::string> {
+  ImplicitConversionSequence conversion;
+  conversion.rank = ConversionRank::kExactMatch;
+  conversion.steps.push_back({ImplicitCastKind::kIdentity, object.type});
+
+  if (!function->isImplicitObjectMemberFunction()) return conversion;
+
+  auto functionType = type_cast<FunctionType>(function->type());
+  if (!functionType) return conversion;
+
+  const auto functionCv = functionType->cvQualifiers();
+  const auto functionRef = functionType->refQualifier();
+  if (!cv_is_subset_of(object.cv, functionCv)) {
+    return std::unexpected(std::format(
+        "'this' argument has type '{}', but function is not "
+        "marked {}",
+        to_string(object.type), is_const(object.cv) ? "const" : "volatile"));
+  }
+
+  const bool objectIsLvalue = object.valueCategory == ValueCategory::kLValue;
+
+  if (functionRef == RefQualifier::kRvalue && objectIsLvalue) {
+    return std::unexpected(
+        "expects an rvalue for the implicit object argument");
+  }
+
+  if (functionRef == RefQualifier::kLvalue && !objectIsLvalue &&
+      !(is_const(functionCv) && !is_volatile(functionCv))) {
+    return std::unexpected(
+        "expects an lvalue for the implicit object argument");
+  }
+
+  conversion.bindsToReference = true;
+  conversion.referenceCv = functionCv;
+  conversion.bindsToRvalueRef = functionRef == RefQualifier::kRvalue;
+  conversion.bindsUnqualifiedImplicitObjectParameter =
+      functionRef == RefQualifier::kNone;
+
+  return conversion;
+}
+
+auto haveSameParameterTypes(FunctionSymbol* lhs, FunctionSymbol* rhs) -> bool {
+  auto lhsType = type_cast<FunctionType>(lhs->type());
+  auto rhsType = type_cast<FunctionType>(rhs->type());
+  if (!lhsType || !rhsType) return false;
+  if (lhsType->isVariadic() != rhsType->isVariadic()) return false;
+  return std::ranges::equal(lhsType->parameterTypes(),
+                            rhsType->parameterTypes());
+}
+
+auto compareDeductionCandidates(const DeductionCandidateInfo& lhs,
+                                const DeductionCandidateInfo& rhs,
+                                bool parameterTypesMatch) -> int {
+  if (parameterTypesMatch &&
+      lhs.fromInheritedConstructor != rhs.fromInheritedConstructor)
+    return lhs.fromInheritedConstructor ? -1 : 1;
+
+  if (lhs.fromDeductionGuide != rhs.fromDeductionGuide)
+    return lhs.fromDeductionGuide ? 1 : -1;
+
+  if (lhs.isCopyDeductionCandidate != rhs.isCopyDeductionCandidate)
+    return lhs.isCopyDeductionCandidate ? 1 : -1;
+
+  if (lhs.fromConstructorTemplate != rhs.fromConstructorTemplate)
+    return lhs.fromConstructorTemplate ? -1 : 1;
+
+  return 0;
+}
+
 auto OverloadResolution::selectBestViableFunction(
-    std::vector<Candidate>& candidates, bool useCvTiebreaker,
-    bool preferNonTemplate) -> OverloadResult {
+    std::vector<Candidate>& candidates, bool preferNonTemplate)
+    -> OverloadResult {
   if (candidates.empty()) return {};
 
   std::vector<Candidate*> best;
@@ -505,6 +578,13 @@ auto OverloadResolution::selectBestViableFunction(
 
     bool currBetter = false;
     bool refBetter = false;
+
+    if (curr.objectConversion && ref.objectConversion) {
+      if (curr.objectConversion->isBetterThan(*ref.objectConversion))
+        currBetter = true;
+      if (ref.objectConversion->isBetterThan(*curr.objectConversion))
+        refBetter = true;
+    }
 
     auto n = std::min(curr.conversions.size(), ref.conversions.size());
     for (size_t j = 0; j < n; ++j) {
@@ -532,8 +612,11 @@ auto OverloadResolution::selectBestViableFunction(
         best.clear();
         best.push_back(&curr);
       }
-    } else if (useCvTiebreaker && curr.exactCvMatch != ref.exactCvMatch) {
-      if (curr.exactCvMatch) {
+    } else if (int order = compareDeductionCandidates(
+                   curr.deduction, ref.deduction,
+                   haveSameParameterTypes(curr.symbol, ref.symbol));
+               order != 0) {
+      if (order > 0) {
         best.clear();
         best.push_back(&curr);
       }
@@ -560,6 +643,30 @@ void OverloadResolution::completeDeferredWinnerBody(
                                   /*argsComplete=*/true);
 }
 
+auto isExcludedInheritedConstructor(const TypeTraits& traits,
+                                    FunctionSymbol* constructor,
+                                    ClassSymbol* classSymbol, int argCount)
+    -> bool {
+  if (argCount != 1) return false;
+
+  auto inherited = constructor->inheritedConstructorOrigin();
+  if (!inherited) return false;
+
+  auto base = symbol_cast<ClassSymbol>(inherited->parent());
+  if (!base) return false;
+
+  auto type = type_cast<FunctionType>(constructor->type());
+  if (!type || type->parameterTypes().empty()) return false;
+
+  auto firstParameter = type->parameterTypes().front();
+  if (!traits.is_reference(firstParameter)) return false;
+
+  auto referenced = traits.remove_reference(firstParameter);
+
+  return traits.is_reference_related(base->type(), referenced) &&
+         traits.is_reference_related(referenced, classSymbol->type());
+}
+
 auto OverloadResolution::resolveConstructor(
     ClassSymbol* classSymbol, const std::vector<ExpressionAST*>& args)
     -> ConstructorResult {
@@ -569,6 +676,16 @@ auto OverloadResolution::resolveConstructor(
 
   const auto constructors = classSymbol->constructors();
 
+  auto reject = [&](FunctionSymbol* ctor, std::string reason) {
+    result.rejected.push_back({ctor, std::move(reason)});
+  };
+
+  auto rejectArity = [&](FunctionSymbol* ctor, int paramCount) {
+    reject(ctor, std::format("requires {} argument{}, but {} {} provided",
+                             paramCount, paramCount == 1 ? "" : "s", argCount,
+                             argCount == 1 ? "was" : "were"));
+  };
+
   for (auto ctor : constructors) {
     if (ctor->canonical() != ctor) continue;
 
@@ -577,7 +694,14 @@ auto OverloadResolution::resolveConstructor(
     List<TemplateArgumentAST*>* deducedArgsForCandidate = nullptr;
 
     if (templateCandidate) {
-      if (templateCandidateArityRejects(ctor, argCount)) continue;
+      if (templateCandidateArityRejects(ctor, argCount)) {
+        auto templateType = type_cast<FunctionType>(ctor->type());
+        rejectArity(
+            ctor, templateType
+                      ? static_cast<int>(templateType->parameterTypes().size())
+                      : argCount);
+        continue;
+      }
 
       List<ExpressionAST*>* expressionList = nullptr;
       auto tail = &expressionList;
@@ -589,7 +713,10 @@ auto OverloadResolution::resolveConstructor(
       TemplateArgumentDeduction deduction(unit_);
       auto deducedArgs = deduction.deduce(ctor, expressionList,
                                           /*explicitTemplateArguments=*/{});
-      if (!deducedArgs.has_value()) continue;
+      if (!deducedArgs.has_value()) {
+        reject(ctor, "template argument deduction failed");
+        continue;
+      }
 
       const auto loc = args.empty() ? classSymbol->location()
                                     : args.front()->firstSourceLocation();
@@ -597,7 +724,10 @@ auto OverloadResolution::resolveConstructor(
       auto instCtor = ASTRewriter::instantiateForArgs(
           unit_, *deducedArgs, ctor, loc, /*argsComplete=*/true,
           /*declarationOnly=*/!functionTemplateHasPackParameter(ctor));
-      if (!instCtor) continue;
+      if (!instCtor) {
+        reject(ctor, "substitution failed for the deduced arguments");
+        continue;
+      }
 
       ctor = instCtor;
       deducedArgsForCandidate = *deducedArgs;
@@ -607,9 +737,36 @@ auto OverloadResolution::resolveConstructor(
     if (!type) continue;
 
     auto paramCount = static_cast<int>(type->parameterTypes().size());
-    if (argCount > paramCount && !type->isVariadic()) continue;
+    if (argCount > paramCount && !type->isVariadic()) {
+      rejectArity(ctor, paramCount);
+      continue;
+    }
     if (argCount < paramCount) {
-      if (argCount < getMinRequiredArgs(ctor, paramCount)) continue;
+      if (argCount < getMinRequiredArgs(ctor, paramCount)) {
+        rejectArity(ctor, paramCount);
+        continue;
+      }
+    }
+
+    if (ASTRewriter::evaluateAssociatedConstraints(unit_, ctor) == false) {
+      reject(ctor, "constraints not satisfied");
+      continue;
+    }
+
+    if (auto owner = symbol_cast<ClassSymbol>(ctor->parent());
+        owner && owner->resolvedDefinition() != classSymbol) {
+      Binder binder{unit_};
+      binder.setReportErrors(!unit_->diagnosticsClient()->isSfinae());
+      auto thunk = binder.inheritedConstructorFor(classSymbol, ctor);
+      if (!thunk) continue;
+      ctor = thunk;
+      type = type_cast<FunctionType>(ctor->type());
+      if (!type) continue;
+    }
+
+    if (isExcludedInheritedConstructor(traits, ctor, classSymbol, argCount)) {
+      reject(ctor, "inherited constructor is excluded by a derived signature");
+      continue;
     }
 
     Candidate cand{ctor};
@@ -623,6 +780,10 @@ auto OverloadResolution::resolveConstructor(
       auto conv = computeImplicitConversionSequence(args[i], *paramIt);
       if (conv.rank == ConversionRank::kNone) {
         cand.viable = false;
+        reject(ctor, std::format(
+                         "no known conversion from '{}' to '{}' for argument "
+                         "{}",
+                         to_string(args[i]->type), to_string(*paramIt), i + 1));
         break;
       }
       cand.conversions.push_back(conv);
@@ -640,8 +801,8 @@ auto OverloadResolution::resolveConstructor(
     if (cand.viable) result.candidates.push_back(std::move(cand));
   }
 
-  auto [bestPtr, ambiguous] = selectBestViableFunction(
-      result.candidates, /*useCvTiebreaker=*/false, /*preferNonTemplate=*/true);
+  auto [bestPtr, ambiguous] =
+      selectBestViableFunction(result.candidates, /*preferNonTemplate=*/true);
   result.best = bestPtr;
   result.ambiguous = ambiguous;
   return result;
@@ -719,23 +880,6 @@ auto OverloadResolution::resolveBinaryOperator(
     ImplicitConversionSequence seq;
     seq.rank = ConversionRank::kExactMatch;
     seq.steps.push_back({ImplicitCastKind::kIdentity, type});
-    return seq;
-  };
-
-  auto rankImplicitObject = [&](const Type* objectType,
-                                const FunctionType* memberFn,
-                                bool* viable) -> ImplicitConversionSequence {
-    *viable = true;
-    auto memberCv = memberFn->cvQualifiers();
-    auto objectCv =
-        traits.get_cv_qualifiers(traits.remove_reference(objectType));
-    if (!cv_is_subset_of(objectCv, memberCv)) {
-      *viable = false;
-      return {};
-    }
-    auto seq = makeExactMatch(objectType);
-    seq.bindsToReference = true;
-    seq.referenceCv = memberCv;
     return seq;
   };
 
@@ -924,9 +1068,14 @@ auto OverloadResolution::resolveBinaryOperator(
             !traits.is_base_of(classType, remove_cvref(leftType))) {
           continue;
         }
-        bool objectViable = false;
-        left = rankImplicitObject(leftType, funcType, &objectViable);
-        if (!objectViable) continue;
+        auto objectConversion = implicitObjectArgumentConversion(
+            candidate,
+            {.type = leftType,
+             .cv = traits.get_cv_qualifiers(traits.remove_reference(leftType)),
+             .valueCategory =
+                 leftExpr ? leftExpr->valueCategory : ValueCategory::kLValue});
+        if (!objectConversion) continue;
+        left = *objectConversion;
         right = rankConversion(rightType, params[0]);
         if (!*right && rightExpr)
           right = stdconv_.computeConversionSequence(rightExpr, params[0]);
@@ -948,9 +1097,14 @@ auto OverloadResolution::resolveBinaryOperator(
             !traits.is_base_of(classType, remove_cvref(leftType))) {
           continue;
         }
-        bool objectViable = false;
-        left = rankImplicitObject(leftType, funcType, &objectViable);
-        if (!objectViable) continue;
+        auto objectConversion = implicitObjectArgumentConversion(
+            candidate,
+            {.type = leftType,
+             .cv = traits.get_cv_qualifiers(traits.remove_reference(leftType)),
+             .valueCategory =
+                 leftExpr ? leftExpr->valueCategory : ValueCategory::kLValue});
+        if (!objectConversion) continue;
+        left = *objectConversion;
       } else {
         if (params.size() != 1) continue;
         left = rankConversion(leftType, params[0]);

--- a/src/parser/cxx/overload_resolution.h
+++ b/src/parser/cxx/overload_resolution.h
@@ -28,7 +28,9 @@
 #include <cxx/type_traits.h>
 #include <cxx/types_fwd.h>
 
+#include <expected>
 #include <optional>
+#include <string>
 #include <vector>
 
 namespace cxx {
@@ -36,13 +38,27 @@ class Arena;
 class Control;
 class TranslationUnit;
 
+struct ImplicitObjectArgument {
+  const Type* type = nullptr;
+  CvQualifiers cv = CvQualifiers::kNone;
+  ValueCategory valueCategory = ValueCategory::kPrValue;
+};
+
+struct DeductionCandidateInfo {
+  bool fromDeductionGuide = false;
+  bool isCopyDeductionCandidate = false;
+  bool fromConstructorTemplate = false;
+  bool fromInheritedConstructor = false;
+};
+
 struct Candidate {
   FunctionSymbol* symbol = nullptr;
+  std::optional<ImplicitConversionSequence> objectConversion;
   std::vector<ImplicitConversionSequence> conversions;
   bool viable = false;
-  bool exactCvMatch = true;
   bool fromTemplate = false;
   List<TemplateArgumentAST*>* deducedTemplateArgs = nullptr;
+  DeductionCandidateInfo deduction;
 };
 
 struct OverloadResult {
@@ -50,11 +66,29 @@ struct OverloadResult {
   bool ambiguous = false;
 };
 
+[[nodiscard]] auto isExcludedInheritedConstructor(const TypeTraits& traits,
+                                                  FunctionSymbol* constructor,
+                                                  ClassSymbol* classSymbol,
+                                                  int argCount) -> bool;
+
+struct RejectedCandidate {
+  FunctionSymbol* symbol = nullptr;
+  std::string reason;
+};
+
 struct ConstructorResult {
   std::vector<Candidate> candidates;
+  std::vector<RejectedCandidate> rejected;
   Candidate* best = nullptr;
   bool ambiguous = false;
 };
+
+[[nodiscard]] auto haveSameParameterTypes(FunctionSymbol* lhs,
+                                          FunctionSymbol* rhs) -> bool;
+
+[[nodiscard]] auto compareDeductionCandidates(const DeductionCandidateInfo& lhs,
+                                              const DeductionCandidateInfo& rhs,
+                                              bool parameterTypesMatch) -> int;
 
 [[nodiscard]] auto templateCandidateArityRejects(FunctionSymbol* pattern,
                                                  int argCount) -> bool;
@@ -76,9 +110,13 @@ class OverloadResolution {
   void wrapWithImplicitCast(ImplicitCastKind castKind, const Type* type,
                             ExpressionAST*& expr);
 
+  [[nodiscard]] auto implicitObjectArgumentConversion(
+      FunctionSymbol* function, const ImplicitObjectArgument& object)
+      -> std::expected<ImplicitConversionSequence, std::string>;
+
   [[nodiscard]] auto selectBestViableFunction(
-      std::vector<Candidate>& candidates, bool useCvTiebreaker = false,
-      bool preferNonTemplate = false) -> OverloadResult;
+      std::vector<Candidate>& candidates, bool preferNonTemplate = false)
+      -> OverloadResult;
 
   [[nodiscard]] auto resolveConstructor(ClassSymbol* classSymbol,
                                         const std::vector<ExpressionAST*>& args)

--- a/src/parser/cxx/parser.cc
+++ b/src/parser/cxx/parser.cc
@@ -46,7 +46,6 @@
 #include <format>
 #include <limits>
 #include <ranges>
-#include <unordered_set>
 
 namespace cxx {
 namespace {
@@ -248,13 +247,6 @@ Parser::Parser(TranslationUnit* unit)
   overrideId_ = control_->getIdentifier("override");
 
   setScope(globalScope_);
-
-#if false
-  mark_maybe_template_name(control_->getIdentifier("__remove_reference_t"));
-  template_names_.insert(control_->getIdentifier("_S_invoke"));
-  template_names_.insert(control_->getIdentifier("_S_nothrow_construct"));
-  template_names_.insert(control_->getIdentifier("_S_nothrow_destroy"));
-#endif
 }
 
 Parser::~Parser() = default;
@@ -452,12 +444,14 @@ auto Parser::parse_override(SourceLocation& loc) -> bool {
 
 auto Parser::parse_type_name(UnqualifiedIdAST*& yyast,
                              NestedNameSpecifierAST* nestedNameSpecifier,
-                             bool isTemplateIntroduced) -> bool {
+                             bool isTemplateIntroduced, TypeNameContext context)
+    -> bool {
   auto lookat_simple_template_id = [&] {
     LookaheadParser lookahead{this};
     SimpleTemplateIdAST* templateId = nullptr;
     if (!parse_simple_template_id(templateId, nestedNameSpecifier,
-                                  isTemplateIntroduced))
+                                  isTemplateIntroduced, MemberAccessKind::kNone,
+                                  context))
       return false;
     yyast = templateId;
     lookahead.commit();
@@ -1025,10 +1019,20 @@ auto Parser::parse_id_expression(IdExpressionAST*& yyast,
   return true;
 }
 
+auto Parser::objectAccessKind(ExpressionAST* objectExpression)
+    -> MemberAccessKind {
+  if (!objectExpression) return MemberAccessKind::kObject;
+  if (!config().checkTypes) return MemberAccessKind::kObject;
+  if (isDependent(unit_, objectExpression->type))
+    return MemberAccessKind::kDependentObject;
+  return MemberAccessKind::kObject;
+}
+
 auto Parser::parse_unqualified_id(UnqualifiedIdAST*& yyast,
                                   NestedNameSpecifierAST* nestedNameSpecifier,
                                   bool isTemplateIntroduced,
-                                  bool inRequiresClause) -> bool {
+                                  bool inRequiresClause,
+                                  MemberAccessKind memberAccess) -> bool {
   if (isCxx()) {
     if (SourceLocation tildeLoc; match(TokenKind::T_TILDE, tildeLoc)) {
       if (DecltypeSpecifierAST* decltypeSpecifier = nullptr;
@@ -1045,7 +1049,8 @@ auto Parser::parse_unqualified_id(UnqualifiedIdAST*& yyast,
       }
 
       UnqualifiedIdAST* name = nullptr;
-      if (!parse_type_name(name, nestedNameSpecifier, isTemplateIntroduced))
+      if (!parse_type_name(name, nestedNameSpecifier, isTemplateIntroduced,
+                           TypeNameContext::kTypeOnly))
         return false;
 
       auto ast = DestructorIdAST::create(pool_);
@@ -1061,7 +1066,8 @@ auto Parser::parse_unqualified_id(UnqualifiedIdAST*& yyast,
     if (!isCxx()) return false;
 
     LookaheadParser lookahead{this};
-    if (!parse_template_id(yyast, nestedNameSpecifier, isTemplateIntroduced))
+    if (!parse_template_id(yyast, nestedNameSpecifier, isTemplateIntroduced,
+                           memberAccess))
       return false;
     lookahead.commit();
     return true;
@@ -1297,6 +1303,22 @@ auto Parser::parse_template_nested_name_specifier(
     }
   }
 
+  if (!ast->symbol) {
+    if (auto classSymbol = symbol_cast<ClassSymbol>(templateId->symbol)) {
+      ast->symbol = classSymbol;
+      if (ctx == NestedNameSpecifierContext::kDeclarative) {
+        if (auto pattern = ASTRewriter::findPartialSpecializationPattern(
+                unit_, classSymbol, templateId->templateArgumentList)) {
+          ast->symbol = pattern;
+        }
+      }
+    } else if (auto alias = symbol_cast<TypeAliasSymbol>(templateId->symbol)) {
+      if (auto classType =
+              type_cast<ClassType>(traits.remove_cv(alias->type())))
+        ast->symbol = classType->symbol();
+    }
+  }
+
   return true;
 }
 
@@ -1380,8 +1402,8 @@ auto Parser::parse_lambda_expression(ExpressionAST*& yyast) -> bool {
 
   if (match(TokenKind::T_LPAREN, ast->lparenLoc)) {
     if (!match(TokenKind::T_RPAREN, ast->rparenLoc)) {
-      if (!parse_parameter_declaration_clause(
-              ast->parameterDeclarationClause)) {
+      if (!parse_parameter_declaration_clause(ast->parameterDeclarationClause,
+                                              TypeNameContext::kTypeOnly)) {
         parse_error("expected a parameter declaration clause");
       }
 
@@ -1395,18 +1417,18 @@ auto Parser::parse_lambda_expression(ExpressionAST*& yyast) -> bool {
 
     parse_optional_attribute_specifier_seq(ast->gnuAtributeList,
                                            AllowedAttributes::kGnuAttribute);
-
-    (void)parse_lambda_specifier_seq(ast->lambdaSpecifierList, ast->symbol);
-
-    (void)parse_noexcept_specifier(ast->exceptionSpecifier);
-
-    (void)parse_trailing_return_type(ast->trailingReturnType);
-
-    parse_optional_attribute_specifier_seq(ast->attributeList,
-                                           AllowedAttributes::kAll);
-
-    (void)parse_requires_clause(ast->requiresClause);
   }
+
+  (void)parse_lambda_specifier_seq(ast->lambdaSpecifierList, ast->symbol);
+
+  (void)parse_noexcept_specifier(ast->exceptionSpecifier);
+
+  parse_optional_attribute_specifier_seq(ast->attributeList,
+                                         AllowedAttributes::kAll);
+
+  (void)parse_trailing_return_type(ast->trailingReturnType);
+
+  if (ast->lparenLoc) (void)parse_requires_clause(ast->requiresClause);
 
   if (!lookat(TokenKind::T_LBRACE)) return false;
 
@@ -1961,7 +1983,8 @@ auto Parser::parse_requirement_parameter_list(
   if (!match(TokenKind::T_LPAREN, lparenLoc)) return false;
 
   if (!match(TokenKind::T_RPAREN, rparenLoc)) {
-    if (!parse_parameter_declaration_clause(parameterDeclarationClause)) {
+    if (!parse_parameter_declaration_clause(parameterDeclarationClause,
+                                            TypeNameContext::kTypeOnly)) {
       parse_error("expected a parmater declaration");
     }
 
@@ -2037,7 +2060,7 @@ auto Parser::parse_type_requirement(RequirementAST*& yyast) -> bool {
   ast->isTemplateIntroduced = match(TokenKind::T_TEMPLATE, ast->templateLoc);
 
   if (!parse_type_name(ast->unqualifiedId, ast->nestedNameSpecifier,
-                       ast->isTemplateIntroduced)) {
+                       ast->isTemplateIntroduced, TypeNameContext::kTypeOnly)) {
     parse_error("expected a type name");
   }
 
@@ -2205,7 +2228,8 @@ auto Parser::parse_member_expression(ExpressionAST*& yyast) -> bool {
 
   if (!parse_unqualified_id(ast->unqualifiedId, ast->nestedNameSpecifier,
                             ast->isTemplateIntroduced,
-                            /*inRequiresClause*/ false))
+                            /*inRequiresClause*/ false,
+                            objectAccessKind(ast->baseExpression)))
     parse_error("expected an unqualified id");
 
   check(ast);
@@ -2305,7 +2329,8 @@ auto Parser::parse_cpp_cast_expression(ExpressionAST*& yyast,
 
   expect(TokenKind::T_LESS, ast->lessLoc);
 
-  if (!parse_type_id(ast->typeId)) parse_error("expected a type id");
+  if (!parse_type_id(ast->typeId, TypeNameContext::kTypeOnly))
+    parse_error("expected a type id");
 
   expect(TokenKind::T_GREATER, ast->greaterLoc);
 
@@ -2331,7 +2356,8 @@ auto Parser::parse_builtin_bit_cast_expression(ExpressionAST*& yyast,
   ast->castLoc = castLoc;
   expect(TokenKind::T_LPAREN, ast->lparenLoc);
 
-  if (!parse_type_id(ast->typeId)) parse_error("expected a type id");
+  if (!parse_type_id(ast->typeId, TypeNameContext::kTypeOnly))
+    parse_error("expected a type id");
 
   expect(TokenKind::T_COMMA, ast->commaLoc);
   parse_expression(ast->expression, ctx);
@@ -2985,7 +3011,9 @@ auto Parser::parse_new_expression(ExpressionAST*& yyast, const ExprContext& ctx)
 
     List<SpecifierAST*>* typeSpecifierList = nullptr;
     DeclSpecs specs{unit_};
-    if (!parse_type_specifier_seq(typeSpecifierList, specs)) return false;
+    if (!parse_type_specifier_seq(typeSpecifierList, specs,
+                                  TypeNameContext::kTypeOnly))
+      return false;
 
     DeclaratorAST* declarator = nullptr;
     Decl decl{specs};
@@ -3014,7 +3042,8 @@ auto Parser::parse_new_expression(ExpressionAST*& yyast, const ExprContext& ctx)
   if (lookat_nested_type_id()) return true;
 
   DeclSpecs specs{unit_};
-  if (!parse_type_specifier_seq(ast->typeSpecifierList, specs)) {
+  if (!parse_type_specifier_seq(ast->typeSpecifierList, specs,
+                                TypeNameContext::kTypeOnly)) {
     parse_error("expected a type specifier");
     specs.finish();
   }
@@ -3140,7 +3169,7 @@ auto Parser::parse_cast_expression_helper(ExpressionAST*& yyast,
 
   TypeIdAST* typeId = nullptr;
 
-  if (!parse_type_id(typeId)) return false;
+  if (!parse_type_id(typeId, TypeNameContext::kTypeOnly)) return false;
 
   SourceLocation rparenLoc;
 
@@ -4391,10 +4420,6 @@ auto Parser::parse_alias_declaration(DeclarationAST*& yyast,
   symbol->setTemplateDeclaration(templateHead);
   if (templateHead) symbol->setTemplateParameters(templateHead->symbol);
 
-  if (is_template(symbol)) {
-    mark_maybe_template_name(identifier);
-  }
-
   auto ast = AliasDeclarationAST::create(pool_);
   yyast = ast;
 
@@ -4636,7 +4661,13 @@ auto Parser::parse_simple_declaration(DeclarationAST*& yyast,
   auto lookat_decl_specifiers = [&] {
     LookaheadParser lookahead{this};
 
-    if (!parse_decl_specifier_seq(declSpecifierList, specs)) return false;
+    auto typeNameContext = ctx == BindingContext::kBlock ||
+                                   ctx == BindingContext::kInitStatement ||
+                                   ctx == BindingContext::kCondition
+                               ? TypeNameContext::kGeneral
+                               : TypeNameContext::kTypeOnly;
+    if (!parse_decl_specifier_seq(declSpecifierList, specs, typeNameContext))
+      return false;
 
     if (!specs.hasTypeOrSizeSpecifier()) return false;
     lookahead.commit();
@@ -4742,10 +4773,6 @@ auto Parser::parse_simple_declaration(
       functionSymbol->setTemplateParameters(templateHead->symbol);
     }
 
-    if (ctx == BindingContext::kTemplate || templateHead) {
-      mark_maybe_template_name(declarator);
-    }
-
     FunctionBodyAST* functionBody = nullptr;
     if (!parse_function_body(functionBody))
       parse_error("expected function body");
@@ -4792,11 +4819,6 @@ auto Parser::parse_simple_declaration(
   if (!parse_init_declarator(initDeclarator, declarator, decl, ctx,
                              templateHead))
     return false;
-
-  if (ctx == BindingContext::kTemplate) {
-    auto declarator = initDeclarator->declarator;
-    mark_maybe_template_name(declarator);
-  }
 
   *declIt = make_list_node(pool_, initDeclarator);
   declIt = &(*declIt)->next;
@@ -4891,7 +4913,6 @@ auto Parser::parse_notypespec_function_definition(
   if (auto templateHead = specs.templateHead) {
     functionSymbol->setTemplateDeclaration(templateHead);
     functionSymbol->setTemplateParameters(templateHead->symbol);
-    mark_maybe_template_name(declarator);
   }
 
   SourceLocation semicolonLoc;
@@ -5044,8 +5065,8 @@ auto Parser::parse_attribute_declaration(DeclarationAST*& yyast) -> bool {
   return true;
 }
 
-auto Parser::parse_decl_specifier(SpecifierAST*& yyast, DeclSpecs& specs)
-    -> bool {
+auto Parser::parse_decl_specifier(SpecifierAST*& yyast, DeclSpecs& specs,
+                                  TypeNameContext context) -> bool {
   switch (TokenKind(LA())) {
     case TokenKind::T_TYPEDEF: {
       auto ast = TypedefSpecifierAST::create(pool_);
@@ -5109,7 +5130,7 @@ auto Parser::parse_decl_specifier(SpecifierAST*& yyast, DeclSpecs& specs)
       if (parse_function_specifier(yyast, specs)) return true;
 
       if (!specs.no_typespecs) {
-        return parse_defining_type_specifier(yyast, specs);
+        return parse_defining_type_specifier(yyast, specs, context);
       }
 
       return false;
@@ -5117,13 +5138,14 @@ auto Parser::parse_decl_specifier(SpecifierAST*& yyast, DeclSpecs& specs)
 }
 
 auto Parser::parse_decl_specifier_seq(List<SpecifierAST*>*& yyast,
-                                      DeclSpecs& specs) -> bool {
+                                      DeclSpecs& specs, TypeNameContext context)
+    -> bool {
   auto it = &yyast;
 
   specs.no_typespecs = false;
 
   SpecifierAST* specifier = nullptr;
-  if (!parse_decl_specifier(specifier, specs)) return false;
+  if (!parse_decl_specifier(specifier, specs, context)) return false;
 
   List<AttributeSpecifierAST*>* attributes = nullptr;
   parse_optional_attribute_specifier_seq(attributes);
@@ -5133,7 +5155,7 @@ auto Parser::parse_decl_specifier_seq(List<SpecifierAST*>*& yyast,
 
   specifier = nullptr;
 
-  while (parse_decl_specifier(specifier, specs)) {
+  while (parse_decl_specifier(specifier, specs, context)) {
     List<AttributeSpecifierAST*>* attributes = nullptr;
     parse_optional_attribute_specifier_seq(attributes);
 
@@ -5272,10 +5294,10 @@ auto Parser::parse_explicit_specifier(SpecifierAST*& yyast, DeclSpecs& specs)
   return true;
 }
 
-auto Parser::parse_type_specifier(SpecifierAST*& yyast, DeclSpecs& specs)
-    -> bool {
+auto Parser::parse_type_specifier(SpecifierAST*& yyast, DeclSpecs& specs,
+                                  TypeNameContext context) -> bool {
   if (parse_cv_qualifier(yyast, specs)) return true;
-  if (parse_simple_type_specifier(yyast, specs)) return true;
+  if (parse_simple_type_specifier(yyast, specs, context)) return true;
   if (parse_elaborated_type_specifier(yyast, specs)) return true;
   if (parse_splicer_specifier(yyast, specs)) return true;
   if (parse_typename_specifier(yyast, specs)) return true;
@@ -5283,13 +5305,14 @@ auto Parser::parse_type_specifier(SpecifierAST*& yyast, DeclSpecs& specs)
 }
 
 auto Parser::parse_type_specifier_seq(List<SpecifierAST*>*& yyast,
-                                      DeclSpecs& specs) -> bool {
+                                      DeclSpecs& specs, TypeNameContext context)
+    -> bool {
   auto it = &yyast;
 
   specs.no_class_or_enum_specs = true;
 
   SpecifierAST* typeSpecifier = nullptr;
-  if (!parse_type_specifier(typeSpecifier, specs)) return false;
+  if (!parse_type_specifier(typeSpecifier, specs, context)) return false;
 
   List<AttributeSpecifierAST*>* attributes = nullptr;
   parse_optional_attribute_specifier_seq(attributes);
@@ -5308,7 +5331,7 @@ auto Parser::parse_type_specifier_seq(List<SpecifierAST*>*& yyast,
 
     typeSpecifier = nullptr;
 
-    if (!parse_type_specifier(typeSpecifier, specs)) {
+    if (!parse_type_specifier(typeSpecifier, specs, context)) {
       rewind(before_type_specifier);
       break;
     }
@@ -5351,7 +5374,8 @@ void Parser::parse_optional_type_qualifier_seq(List<SpecifierAST*>*& yyast,
 }
 
 auto Parser::parse_defining_type_specifier(SpecifierAST*& yyast,
-                                           DeclSpecs& specs) -> bool {
+                                           DeclSpecs& specs,
+                                           TypeNameContext context) -> bool {
   if (!specs.no_class_or_enum_specs && !specs.hasTypeSpecifier()) {
     LookaheadParser lookahead{this};
 
@@ -5377,7 +5401,7 @@ auto Parser::parse_defining_type_specifier(SpecifierAST*& yyast,
     }
   }
 
-  return parse_type_specifier(yyast, specs);
+  return parse_type_specifier(yyast, specs, context);
 }
 
 auto Parser::parse_defining_type_specifier_seq(List<SpecifierAST*>*& yyast,
@@ -5386,7 +5410,9 @@ auto Parser::parse_defining_type_specifier_seq(List<SpecifierAST*>*& yyast,
 
   SpecifierAST* typeSpecifier = nullptr;
 
-  if (!parse_defining_type_specifier(typeSpecifier, specs)) return false;
+  if (!parse_defining_type_specifier(typeSpecifier, specs,
+                                     TypeNameContext::kTypeOnly))
+    return false;
 
   List<AttributeSpecifierAST*>* attributes = nullptr;
 
@@ -5404,7 +5430,8 @@ auto Parser::parse_defining_type_specifier_seq(List<SpecifierAST*>*& yyast,
 
     typeSpecifier = nullptr;
 
-    if (!parse_defining_type_specifier(typeSpecifier, specs)) {
+    if (!parse_defining_type_specifier(typeSpecifier, specs,
+                                       TypeNameContext::kTypeOnly)) {
       rewind(before_type_specifier);
       break;
     }
@@ -5421,8 +5448,8 @@ auto Parser::parse_defining_type_specifier_seq(List<SpecifierAST*>*& yyast,
   return true;
 }
 
-auto Parser::parse_simple_type_specifier(SpecifierAST*& yyast, DeclSpecs& specs)
-    -> bool {
+auto Parser::parse_simple_type_specifier(SpecifierAST*& yyast, DeclSpecs& specs,
+                                         TypeNameContext context) -> bool {
   if (parse_size_type_specifier(yyast, specs)) return true;
   if (parse_sign_type_specifier(yyast, specs)) return true;
   if (parse_complex_type_specifier(yyast, specs)) return true;
@@ -5435,7 +5462,7 @@ auto Parser::parse_simple_type_specifier(SpecifierAST*& yyast, DeclSpecs& specs)
   if (parse_unary_builtin_type_specifier(yyast, specs)) return true;
   if (parse_atomic_type_specifier(yyast, specs)) return true;
   if (parse_bitint_type_specifier(yyast, specs)) return true;
-  if (parse_named_type_specifier(yyast, specs)) return true;
+  if (parse_named_type_specifier(yyast, specs, context)) return true;
   if (parse_decltype_specifier_type_specifier(yyast, specs)) return true;
 
   return false;
@@ -5510,8 +5537,8 @@ auto Parser::parse_complex_type_specifier(SpecifierAST*& yyast,
   return true;
 }
 
-auto Parser::parse_named_type_specifier(SpecifierAST*& yyast, DeclSpecs& specs)
-    -> bool {
+auto Parser::parse_named_type_specifier(SpecifierAST*& yyast, DeclSpecs& specs,
+                                        TypeNameContext context) -> bool {
   if (specs.isUnsigned || specs.isSigned || specs.isShort || specs.isLong)
     return false;
 
@@ -5529,8 +5556,8 @@ auto Parser::parse_named_type_specifier(SpecifierAST*& yyast, DeclSpecs& specs)
   auto id = unit_->identifier(currentLocation());
 
   UnqualifiedIdAST* unqualifiedId = nullptr;
-  if (!parse_type_name(unqualifiedId, nestedNameSpecifier,
-                       isTemplateIntroduced)) {
+  if (!parse_type_name(unqualifiedId, nestedNameSpecifier, isTemplateIntroduced,
+                       context)) {
     return false;
   }
 
@@ -5554,17 +5581,25 @@ auto Parser::parse_named_type_specifier(SpecifierAST*& yyast, DeclSpecs& specs)
 
   } else {
     Symbol* resolvedType = nullptr;
-    if (!nestedNameSpecifier) {
-      if (auto nameId = ast_cast<NameIdAST>(unqualifiedId)) {
+    if (auto nameId = ast_cast<NameIdAST>(unqualifiedId)) {
+      if (nestedNameSpecifier && nestedNameSpecifier->symbol) {
+        resolvedType =
+            qualifiedLookup(nestedNameSpecifier->symbol, nameId->identifier);
+      } else {
         resolvedType =
             unqualifiedLookupType(lexicalScope_, nameId->identifier, isCxx());
       }
     }
     symbol = binder_.resolve(nestedNameSpecifier, unqualifiedId, checkTemplates,
                              resolvedType);
+    if (!symbol) symbol = resolvedType;
   }
 
-  if (!is_type(symbol) && config().checkTypes) {
+  const auto dependentTypeOnlyName =
+      !symbol && context == TypeNameContext::kTypeOnly && nestedNameSpecifier &&
+      isDependent(unit_, nestedNameSpecifier);
+
+  if (!is_type(symbol) && !dependentTypeOnlyName && config().checkTypes) {
     auto name = get_name(control_, unqualifiedId);
     parse_error(unqualifiedId->firstSourceLocation(),
                 std::format("'{}' is not a type", to_string(name)));
@@ -5757,32 +5792,18 @@ auto Parser::parse_primitive_type_specifier(SpecifierAST*& yyast,
   }
 }
 
-auto Parser::maybe_template_name(const Identifier* id) -> bool {
-  if (!config().fuzzyTemplateResolution) return true;
-  if (id->builtinTemplate() != BuiltinTemplateKind::T_NONE) return true;
-  if (template_names_.contains(id)) return true;
-  if (concept_names_.contains(id)) return true;
-  return false;
-}
-
-void Parser::mark_maybe_template_name(const Identifier* id) {
-  if (!config().fuzzyTemplateResolution) return;
-  if (!id) return;
-  template_names_.emplace(id);
-}
-
-void Parser::mark_maybe_template_name(UnqualifiedIdAST* name) {
-  if (auto nameId = ast_cast<NameIdAST>(name)) {
-    mark_maybe_template_name(nameId->identifier);
+auto abbreviatedPlaceholderSpecifier(ParameterDeclarationAST* param)
+    -> SpecifierAST* {
+  for (auto s = param->typeSpecifierList; s; s = s->next) {
+    if (ast_cast<AutoTypeSpecifierAST>(s->value)) return s->value;
+    if (ast_cast<PlaceholderTypeSpecifierAST>(s->value)) return s->value;
   }
+  return nullptr;
 }
 
-void Parser::mark_maybe_template_name(DeclaratorAST* declarator) {
-  if (!declarator) return;
-  auto declaratorId = ast_cast<IdDeclaratorAST>(declarator->coreDeclarator);
-  if (!declaratorId) return;
-  if (declaratorId->nestedNameSpecifier) return;
-  mark_maybe_template_name(declaratorId->unqualifiedId);
+auto abbreviatedTypeConstraint(SpecifierAST* specifier) -> TypeConstraintAST* {
+  auto placeholder = ast_cast<PlaceholderTypeSpecifierAST>(specifier);
+  return placeholder ? placeholder->typeConstraint : nullptr;
 }
 
 void Parser::synthesizeAbbreviatedTemplateParams(
@@ -5790,10 +5811,7 @@ void Parser::synthesizeAbbreviatedTemplateParams(
   if (!params) return;
 
   auto hasAutoSpec = [](ParameterDeclarationAST* param) -> bool {
-    for (auto s = param->typeSpecifierList; s; s = s->next) {
-      if (ast_cast<AutoTypeSpecifierAST>(s->value)) return true;
-    }
-    return false;
+    return abbreviatedPlaceholderSpecifier(param) != nullptr;
   };
 
   int autoCount = 0;
@@ -5838,14 +5856,32 @@ void Parser::synthesizeAbbreviatedTemplateParams(
     auto syntheticName =
         control_->getIdentifier(std::format("__auto_{}", paramIndex));
 
-    auto tyParam = TypenameTypeParameterAST::create(pool_);
-    tyParam->isPack = it->value->isPack;
-    tyParam->identifier = syntheticName;
+    auto placeholder = abbreviatedPlaceholderSpecifier(it->value);
+    auto typeConstraint = abbreviatedTypeConstraint(placeholder);
+
+    TemplateParameterAST* tyParam = nullptr;
+
+    if (typeConstraint) {
+      auto constrained = ConstraintTypeParameterAST::create(pool_);
+      constrained->typeConstraint = typeConstraint;
+      constrained->identifier = syntheticName;
+      if (it->value->isPack) constrained->ellipsisLoc = it->value->thisLoc;
+      tyParam = constrained;
+    } else {
+      auto typeParameter = TypenameTypeParameterAST::create(pool_);
+      typeParameter->isPack = it->value->isPack;
+      typeParameter->identifier = syntheticName;
+      tyParam = typeParameter;
+    }
 
     {
       auto scopeGuard = CombinedScopeGuard{this};
       setScope(templDecl->symbol);
-      binder_.bind(tyParam, paramIndex, /*depth=*/0);
+      if (auto constrained = ast_cast<ConstraintTypeParameterAST>(tyParam))
+        binder_.bind(constrained, paramIndex, /*depth=*/0);
+      else
+        binder_.bind(ast_cast<TypenameTypeParameterAST>(tyParam), paramIndex,
+                     /*depth=*/0);
     }
 
     auto node = make_list_node<TemplateParameterAST>(pool_, tyParam);
@@ -5858,12 +5894,11 @@ void Parser::synthesizeAbbreviatedTemplateParams(
     }
 
     for (auto s = it->value->typeSpecifierList; s; s = s->next) {
-      if (ast_cast<AutoTypeSpecifierAST>(s->value)) {
-        auto namedSpec = NamedTypeSpecifierAST::create(pool_);
-        namedSpec->symbol = tyParam->symbol;
-        s->value = namedSpec;
-        break;
-      }
+      if (s->value != placeholder) continue;
+      auto namedSpec = NamedTypeSpecifierAST::create(pool_);
+      namedSpec->symbol = tyParam->symbol;
+      s->value = namedSpec;
+      break;
     }
 
     auto newParamType = getDeclaratorType(unit_, it->value->declarator,
@@ -5893,10 +5928,7 @@ void Parser::synthesizeLambdaAbbreviatedTemplateParams(
   if (!params) return;
 
   auto hasAutoSpec = [](ParameterDeclarationAST* param) -> bool {
-    for (auto s = param->typeSpecifierList; s; s = s->next) {
-      if (ast_cast<AutoTypeSpecifierAST>(s->value)) return true;
-    }
-    return false;
+    return abbreviatedPlaceholderSpecifier(param) != nullptr;
   };
 
   bool any = false;
@@ -5918,11 +5950,25 @@ void Parser::synthesizeLambdaAbbreviatedTemplateParams(
     auto syntheticName =
         control_->getIdentifier(std::format("__auto_{}", paramIndex));
 
-    auto tyParam = TypenameTypeParameterAST::create(pool_);
-    tyParam->isPack = it->value->isPack;
-    tyParam->identifier = syntheticName;
+    auto placeholder = abbreviatedPlaceholderSpecifier(it->value);
+    auto typeConstraint = abbreviatedTypeConstraint(placeholder);
 
-    binder_.bind(tyParam, paramIndex, templateParameterDepth_);
+    TemplateParameterAST* tyParam = nullptr;
+
+    if (typeConstraint) {
+      auto constrained = ConstraintTypeParameterAST::create(pool_);
+      constrained->typeConstraint = typeConstraint;
+      constrained->identifier = syntheticName;
+      if (it->value->isPack) constrained->ellipsisLoc = it->value->thisLoc;
+      tyParam = constrained;
+      binder_.bind(constrained, paramIndex, templateParameterDepth_);
+    } else {
+      auto typeParameter = TypenameTypeParameterAST::create(pool_);
+      typeParameter->isPack = it->value->isPack;
+      typeParameter->identifier = syntheticName;
+      tyParam = typeParameter;
+      binder_.bind(typeParameter, paramIndex, templateParameterDepth_);
+    }
 
     auto node = make_list_node<TemplateParameterAST>(pool_, tyParam);
     if (!ast->templateParameterList) {
@@ -5934,12 +5980,11 @@ void Parser::synthesizeLambdaAbbreviatedTemplateParams(
     }
 
     for (auto s = it->value->typeSpecifierList; s; s = s->next) {
-      if (ast_cast<AutoTypeSpecifierAST>(s->value)) {
-        auto namedSpec = NamedTypeSpecifierAST::create(pool_);
-        namedSpec->symbol = tyParam->symbol;
-        s->value = namedSpec;
-        break;
-      }
+      if (s->value != placeholder) continue;
+      auto namedSpec = NamedTypeSpecifierAST::create(pool_);
+      namedSpec->symbol = tyParam->symbol;
+      s->value = namedSpec;
+      break;
     }
 
     auto newParamType = getDeclaratorType(unit_, it->value->declarator,
@@ -5982,21 +6027,6 @@ void Parser::check_type_traits() {
 #endif
 
   rewind(typeTraitLoc);
-}
-
-auto Parser::is_template(Symbol* symbol) const -> bool {
-  if (!symbol) return false;
-  if (symbol->isTemplateTypeParameter()) return true;
-  if (symbol_cast<TemplateParametersSymbol>(symbol->parent())) return true;
-  if (auto alias = symbol_cast<TypeAliasSymbol>(symbol))
-    return alias->templateParameters() != nullptr;
-  if (auto cls = symbol_cast<ClassSymbol>(symbol))
-    return cls->templateParameters() != nullptr;
-  if (auto func = symbol_cast<FunctionSymbol>(symbol))
-    return func->templateParameters() != nullptr;
-  if (auto var = symbol_cast<VariableSymbol>(symbol))
-    return var->templateParameters() != nullptr;
-  return false;
 }
 
 auto Parser::evaluate_constant_expression(ExpressionAST* expr)
@@ -6087,7 +6117,6 @@ auto Parser::parse_elaborated_type_specifier(SpecifierAST*& yyast,
       parse_simple_template_id(templateId)) {
     ast->unqualifiedId = templateId;
 
-    mark_maybe_template_name(templateId->identifier);
   } else {
     NameIdAST* nameId = nullptr;
     (void)parse_name_id(nameId);
@@ -6095,7 +6124,8 @@ auto Parser::parse_elaborated_type_specifier(SpecifierAST*& yyast,
     ast->unqualifiedId = nameId;
   }
 
-  const auto isDeclaration = lookat(TokenKind::T_SEMICOLON);
+  const auto isDeclaration = lookat(TokenKind::T_SEMICOLON) &&
+                             !ast_cast<SimpleTemplateIdAST>(ast->unqualifiedId);
 
   specs.accept(ast);
 
@@ -6297,7 +6327,7 @@ auto Parser::parse_init_declarator(InitDeclaratorAST*& yyast,
   ast->initializer = initializer;
   ast->symbol = symbol;
 
-  check_init_declarator(ast);
+  check_init_declarator(ast, decl.specs.typeSpecifier());
 
   return true;
 }
@@ -6483,9 +6513,14 @@ auto Parser::parse_function_declarator(FunctionDeclaratorChunkAST*& yyast,
 
   SourceLocation rparenLoc;
   ParameterDeclarationClauseAST* parameterDeclarationClause = nullptr;
+  const auto parameterTypeNameContext =
+      symbol_cast<ClassSymbol>(binder_.declaringScope())
+          ? TypeNameContext::kTypeOnly
+          : TypeNameContext::kGeneral;
 
   if (!match(TokenKind::T_RPAREN, rparenLoc)) {
-    if (!parse_parameter_declaration_clause(parameterDeclarationClause)) {
+    if (!parse_parameter_declaration_clause(parameterDeclarationClause,
+                                            parameterTypeNameContext)) {
       restoreAbbreviated();
       return false;
     }
@@ -6560,7 +6595,8 @@ auto Parser::parse_trailing_return_type(TrailingReturnTypeAST*& yyast) -> bool {
 
   ast->minusGreaterLoc = minusGreaterLoc;
 
-  if (!parse_type_id(ast->typeId)) parse_error("expected a type id");
+  if (!parse_type_id(ast->typeId, TypeNameContext::kTypeOnly))
+    parse_error("expected a type id");
 
   return true;
 }
@@ -6724,10 +6760,10 @@ auto Parser::parse_declarator_id(CoreDeclaratorAST*& yyast, Decl& decl,
   return true;
 }
 
-auto Parser::parse_type_id(TypeIdAST*& yyast) -> bool {
+auto Parser::parse_type_id(TypeIdAST*& yyast, TypeNameContext context) -> bool {
   List<SpecifierAST*>* specifierList = nullptr;
   DeclSpecs specs{unit_};
-  if (!parse_type_specifier_seq(specifierList, specs)) return false;
+  if (!parse_type_specifier_seq(specifierList, specs, context)) return false;
 
   yyast = TypeIdAST::create(pool_);
   yyast->typeSpecifierList = specifierList;
@@ -6795,7 +6831,7 @@ auto Parser::parse_nested_declarator(CoreDeclaratorAST*& yyast, Decl& decl,
 }
 
 auto Parser::parse_parameter_declaration_clause(
-    ParameterDeclarationClauseAST*& yyast) -> bool {
+    ParameterDeclarationClauseAST*& yyast, TypeNameContext context) -> bool {
   const auto start = currentLocation();
 
   if (auto entry = parameter_declaration_clauses_.get(start)) {
@@ -6815,7 +6851,7 @@ auto Parser::parse_parameter_declaration_clause(
     yyast = ast;
 
     ast->isVariadic = true;
-  } else if (parse_parameter_declaration_list(ast)) {
+  } else if (parse_parameter_declaration_list(ast, context)) {
     yyast = ast;
 
     match(TokenKind::T_COMMA, ast->commaLoc);
@@ -6830,7 +6866,7 @@ auto Parser::parse_parameter_declaration_clause(
 }
 
 auto Parser::parse_parameter_declaration_list(
-    ParameterDeclarationClauseAST* ast) -> bool {
+    ParameterDeclarationClauseAST* ast, TypeNameContext context) -> bool {
   if (lookat(TokenKind::T_VOID, TokenKind::T_RPAREN)) {
     consumeToken();
     return true;
@@ -6844,7 +6880,8 @@ auto Parser::parse_parameter_declaration_list(
 
   ParameterDeclarationAST* declaration = nullptr;
 
-  if (!parse_parameter_declaration(declaration, /*templParam*/ false)) {
+  if (!parse_parameter_declaration(declaration, /*templParam*/ false,
+                                   context)) {
     return false;
   }
 
@@ -6856,7 +6893,8 @@ auto Parser::parse_parameter_declaration_list(
   while (match(TokenKind::T_COMMA, commaLoc)) {
     ParameterDeclarationAST* declaration = nullptr;
 
-    if (!parse_parameter_declaration(declaration, /*templParam*/ false)) {
+    if (!parse_parameter_declaration(declaration, /*templParam*/ false,
+                                     context)) {
       rewind(commaLoc);
       break;
     }
@@ -6869,7 +6907,8 @@ auto Parser::parse_parameter_declaration_list(
 }
 
 auto Parser::parse_parameter_declaration(ParameterDeclarationAST*& yyast,
-                                         bool templParam) -> bool {
+                                         bool templParam,
+                                         TypeNameContext context) -> bool {
   auto ast = ParameterDeclarationAST::create(pool_);
   yyast = ast;
 
@@ -6881,7 +6920,8 @@ auto Parser::parse_parameter_declaration(ParameterDeclarationAST*& yyast,
 
   ast->isThisIntroduced = match(TokenKind::T_THIS, ast->thisLoc);
 
-  if (!parse_decl_specifier_seq(ast->typeSpecifierList, specs)) return false;
+  if (!parse_decl_specifier_seq(ast->typeSpecifierList, specs, context))
+    return false;
 
   Decl decl{specs};
   parse_optional_declarator_or_abstract_declarator(ast->declarator, decl);
@@ -7328,11 +7368,16 @@ auto Parser::parse_enum_specifier(SpecifierAST*& yyast, DeclSpecs& specs)
     pushScope(enumScope);
 
   if (!match(TokenKind::T_RBRACE, ast->rbraceLoc)) {
-    parse_enumerator_list(ast->enumeratorList, ast->symbol->type());
+    parse_enumerator_list(ast->enumeratorList,
+                          enumeratorTypeInEnumSpecifier(ast->symbol));
 
     match(TokenKind::T_COMMA, ast->commaLoc);
 
     expect(TokenKind::T_RBRACE, ast->rbraceLoc);
+
+    for (auto enumerator : ListView{ast->enumeratorList}) {
+      if (enumerator->symbol) enumerator->symbol->setType(ast->symbol->type());
+    }
   }
 
   if (isCxx()) {
@@ -7443,6 +7488,18 @@ auto Parser::parse_enum_base(SourceLocation& colonLoc,
   }
 
   return true;
+}
+
+auto Parser::enumeratorTypeInEnumSpecifier(Symbol* enumSymbol) -> const Type* {
+  if (auto scopedEnum = symbol_cast<ScopedEnumSymbol>(enumSymbol))
+    return scopedEnum->underlyingType();
+
+  if (auto unscopedEnum = symbol_cast<EnumSymbol>(enumSymbol);
+      unscopedEnum && unscopedEnum->hasFixedUnderlyingType()) {
+    return unscopedEnum->underlyingType();
+  }
+
+  return enumSymbol->type();
 }
 
 void Parser::parse_enumerator_list(List<EnumeratorAST*>*& yyast,
@@ -8731,10 +8788,6 @@ auto Parser::parse_class_specifier(ClassSpecifierAST*& yyast, DeclSpecs& specs)
     ast->isFinal = true;
   }
 
-  if (scope()->isTemplateParameters()) {
-    mark_maybe_template_name(unqualifiedId);
-  }
-
   auto _ = CombinedScopeGuard{this};
 
   binder_.bind(ast, specs);
@@ -8904,7 +8957,8 @@ auto Parser::parse_member_declaration_helper(DeclarationAST*& yyast) -> bool {
     lastDeclSpecifier = &(*lastDeclSpecifier)->next;
   }
 
-  (void)parse_decl_specifier_seq(*lastDeclSpecifier, specs);
+  (void)parse_decl_specifier_seq(*lastDeclSpecifier, specs,
+                                 TypeNameContext::kTypeOnly);
 
   if (!specs.hasTypeOrSizeSpecifier()) return false;
 
@@ -8964,7 +9018,6 @@ auto Parser::parse_member_declaration_helper(DeclarationAST*& yyast) -> bool {
     if (templateHead) {
       functionSymbol->setTemplateDeclaration(templateHead);
       functionSymbol->setTemplateParameters(templateHead->symbol);
-      mark_maybe_template_name(declarator);
     }
 
     auto _ = CombinedScopeGuard{this};
@@ -9239,7 +9292,9 @@ auto Parser::parse_conversion_function_id(ConversionFunctionIdAST*& yyast)
 
   List<SpecifierAST*>* typeSpecifierList = nullptr;
   DeclSpecs specs{unit_};
-  if (!parse_type_specifier_seq(typeSpecifierList, specs)) return false;
+  if (!parse_type_specifier_seq(typeSpecifierList, specs,
+                                TypeNameContext::kTypeOnly))
+    return false;
 
   lookahead.commit();
 
@@ -9393,7 +9448,7 @@ auto Parser::parse_class_or_decltype(
 
   UnqualifiedIdAST* unqualifiedName = nullptr;
   if (!parse_type_name(unqualifiedName, nestedNameSpecifier,
-                       isTemplateIntroduced)) {
+                       isTemplateIntroduced, TypeNameContext::kTypeOnly)) {
     parse_error("expected a class name");
   }
 
@@ -9884,7 +9939,9 @@ void Parser::parse_template_parameter(TemplateParameterAST*& yyast) {
 
   ParameterDeclarationAST* parameter = nullptr;
 
-  if (!parse_parameter_declaration(parameter, /*templParam*/ true)) return;
+  if (!parse_parameter_declaration(parameter, /*templParam*/ true,
+                                   TypeNameContext::kTypeOnly))
+    return;
 
   lookahead.commit();
 
@@ -9940,7 +9997,8 @@ auto Parser::parse_typename_type_parameter(TemplateParameterAST*& yyast)
   binder_.bind(ast, templateParameterCount_, templateParameterDepth_);
 
   if (match(TokenKind::T_EQUAL, ast->equalLoc)) {
-    if (!parse_type_id(ast->typeId)) parse_error("expected a type id");
+    if (!parse_type_id(ast->typeId, TypeNameContext::kTypeOnly))
+      parse_error("expected a type id");
   }
 
   return true;
@@ -9980,8 +10038,6 @@ void Parser::parse_template_type_parameter(TemplateParameterAST*& yyast) {
 
   if (match(TokenKind::T_IDENTIFIER, ast->identifierLoc)) {
     ast->identifier = unit_->identifier(ast->identifierLoc);
-
-    mark_maybe_template_name(ast->identifier);
   }
 
   binder_.bind(ast, templateParameterCount_, templateParameterDepth_);
@@ -10013,7 +10069,7 @@ auto Parser::parse_constraint_type_parameter(TemplateParameterAST*& yyast)
   TypeIdAST* typeId = nullptr;
 
   if (match(TokenKind::T_EQUAL, equalLoc)) {
-    if (!parse_type_id(typeId)) {
+    if (!parse_type_id(typeId, TypeNameContext::kTypeOnly)) {
       return false;
     }
   }
@@ -10047,6 +10103,7 @@ auto Parser::parse_type_constraint(TypeConstraintAST*& yyast,
   NestedNameSpecifierAST* nestedNameSpecifier = nullptr;
   SourceLocation identifierLoc;
   const Identifier* identifier = nullptr;
+  ConceptSymbol* conceptSymbol = nullptr;
 
   auto lookat_type_constraint = [&] {
     LookaheadParser lookahead{this};
@@ -10058,7 +10115,22 @@ auto Parser::parse_type_constraint(TypeConstraintAST*& yyast,
 
     identifier = unit_->identifier(identifierLoc);
 
-    if (!concept_names_.contains(identifier)) return false;
+    Symbol* symbol = nullptr;
+    if (nestedNameSpecifier && nestedNameSpecifier->symbol) {
+      symbol = qualifiedLookup(
+          nestedNameSpecifier->symbol, identifier, [](Symbol* symbol) {
+            return symbol_cast<ConceptSymbol>(symbol) != nullptr;
+          });
+    } else {
+      symbol =
+          unqualifiedLookup(lexicalScope(), identifier, [](Symbol* symbol) {
+            return symbol_cast<ConceptSymbol>(symbol) != nullptr;
+          });
+    }
+
+    if (!symbol) return false;
+
+    conceptSymbol = symbol_cast<ConceptSymbol>(symbol);
 
     lookahead.commit();
 
@@ -10073,6 +10145,7 @@ auto Parser::parse_type_constraint(TypeConstraintAST*& yyast,
   ast->nestedNameSpecifier = nestedNameSpecifier;
   ast->identifierLoc = identifierLoc;
   ast->identifier = identifier;
+  ast->symbol = conceptSymbol;
 
   if (match(TokenKind::T_LESS, ast->lessLoc)) {
     if (!parse_template_argument_list(ast->templateArgumentList)) {
@@ -10084,6 +10157,25 @@ auto Parser::parse_type_constraint(TypeConstraintAST*& yyast,
 
   return true;
 }
+
+namespace {
+auto findTemplatedSymbolInLookupScope(Symbol* candidate, const Name* name)
+    -> Symbol* {
+  if (!candidate || !name) return nullptr;
+  while (auto usingDeclaration =
+             symbol_cast<UsingDeclarationSymbol>(candidate)) {
+    candidate = usingDeclaration->target();
+    if (!candidate) return nullptr;
+  }
+  auto declaringScope = candidate->parent();
+  if (!declaringScope) return templated_symbol(candidate);
+  for (auto symbol : declaringScope->find(name)) {
+    if (symbol->isHidden()) continue;
+    if (auto result = templated_symbol(symbol)) return result;
+  }
+  return nullptr;
+}
+}  // namespace
 
 auto Parser::parse_simple_template_id(SimpleTemplateIdAST*& yyast) -> bool {
   if (!lookat(TokenKind::T_IDENTIFIER, TokenKind::T_LESS)) return false;
@@ -10103,58 +10195,50 @@ auto Parser::parse_simple_template_id(SimpleTemplateIdAST*& yyast) -> bool {
     expect(TokenKind::T_GREATER, ast->greaterLoc);
   }
 
-  auto candidate =
-      unqualifiedLookup(lexicalScope(), ast->identifier,
-                        [this](Symbol* symbol) { return is_template(symbol); });
+  auto candidate = unqualifiedLookup(lexicalScope(), ast->identifier);
 
-  ast->symbol = candidate;
+  ast->symbol = findTemplatedSymbolInLookupScope(candidate, ast->identifier);
 
   return true;
 }
 
 auto Parser::parse_simple_template_id(
     SimpleTemplateIdAST*& yyast, NestedNameSpecifierAST* nestedNameSpecifier,
-    bool isTemplateIntroduced) -> bool {
+    bool isTemplateIntroduced, MemberAccessKind memberAccess,
+    TypeNameContext context) -> bool {
   LookaheadParser lookahead{this};
 
   SimpleTemplateIdAST* templateId = nullptr;
   if (!parse_simple_template_id(templateId)) return false;
   if (!templateId->greaterLoc) return false;
 
-  Symbol* candidate = nullptr;
-  if (nestedNameSpecifier && nestedNameSpecifier->symbol)
-    candidate =
-        qualifiedLookup(nestedNameSpecifier->symbol, templateId->identifier);
-  else
-    candidate = unqualifiedLookup(lexicalScope(), templateId->identifier);
+  const auto dependentQualifier =
+      memberAccess == MemberAccessKind::kDependentObject ||
+      isDependentNestedNameSpecifier(nestedNameSpecifier);
 
-  if (auto injected = symbol_cast<InjectedClassNameSymbol>(candidate)) {
-    if (auto cls = injected->classSymbol()) {
-      if (auto primary = cls->primaryTemplateSymbol())
-        candidate = primary;
-      else
-        candidate = cls;
+  if (!isTemplateIntroduced && context != TypeNameContext::kTypeOnly &&
+      dependentQualifier)
+    return false;
+
+  auto lookupCandidate = [&]() -> Symbol* {
+    if (memberAccess != MemberAccessKind::kNone) return nullptr;
+    if (nestedNameSpecifier) {
+      if (!nestedNameSpecifier->symbol) return nullptr;
+      return qualifiedLookup(nestedNameSpecifier->symbol,
+                             templateId->identifier);
     }
-  }
+    return unqualifiedLookup(lexicalScope(), templateId->identifier);
+  };
+
+  Symbol* candidate = lookupCandidate();
 
   if (symbol_cast<NonTypeParameterSymbol>(candidate)) return false;
 
-  Symbol* primaryTemplateSymbol = nullptr;
+  auto primaryTemplateSymbol =
+      findTemplatedSymbolInLookupScope(candidate, templateId->identifier);
 
-  if (is_template(candidate)) {
-    primaryTemplateSymbol = candidate;
-  } else {
-    for (auto overload : views::each_function(candidate)) {
-      if (is_template(overload)) {
-        primaryTemplateSymbol = overload;
-        break;
-      }
-    }
-  }
-
-  if (!primaryTemplateSymbol && !isTemplateIntroduced) {
-    if (!maybe_template_name(templateId->identifier)) return false;
-  }
+  if (candidate && !primaryTemplateSymbol && !isTemplateIntroduced)
+    return false;
 
   templateId->symbol = primaryTemplateSymbol;
 
@@ -10223,7 +10307,8 @@ auto Parser::parse_function_operator_template_id(
 
 auto Parser::parse_template_id(UnqualifiedIdAST*& yyast,
                                NestedNameSpecifierAST* nestedNameSpecifier,
-                               bool isTemplateIntroduced) -> bool {
+                               bool isTemplateIntroduced,
+                               MemberAccessKind memberAccess) -> bool {
   if (!isCxx()) return false;
 
   if (LiteralOperatorTemplateIdAST* templateName = nullptr;
@@ -10240,7 +10325,7 @@ auto Parser::parse_template_id(UnqualifiedIdAST*& yyast,
 
   SimpleTemplateIdAST* templateName = nullptr;
   if (!parse_simple_template_id(templateName, nestedNameSpecifier,
-                                isTemplateIntroduced))
+                                isTemplateIntroduced, memberAccess))
     return false;
 
   yyast = templateName;
@@ -10421,7 +10506,7 @@ auto Parser::parse_deduction_guide(DeclarationAST*& yyast,
 
   expect(TokenKind::T_SEMICOLON, ast->semicolonLoc);
 
-  binder_.bind(ast);
+  binder_.bind(ast, templateHead);
 
   return true;
 }
@@ -10440,10 +10525,6 @@ auto Parser::parse_concept_definition(DeclarationAST*& yyast) -> bool {
   ast->identifier = unit_->identifier(ast->identifierLoc);
 
   binder_.bind(ast);
-
-  if (ast->identifierLoc) {
-    concept_names_.insert(ast->identifier);
-  }
 
   expect(TokenKind::T_EQUAL, ast->equalLoc);
 
@@ -10504,7 +10585,8 @@ auto Parser::parse_typename_specifier(SpecifierAST*& yyast, DeclSpecs& specs)
 
   SimpleTemplateIdAST* templateId = nullptr;
   if (parse_simple_template_id(templateId, nestedNameSpecifier,
-                               isTemplateIntroduced)) {
+                               isTemplateIntroduced, MemberAccessKind::kNone,
+                               TypeNameContext::kTypeOnly)) {
     unqualifiedId = templateId;
   } else {
     NameIdAST* nameId = nullptr;
@@ -10575,7 +10657,7 @@ auto Parser::parse_explicit_instantiation(DeclarationAST*& yyast) -> bool {
       auto candidate = qualifiedLookup(elabSpec->nestedNameSpecifier->symbol,
                                        templateId->identifier);
 
-      if (!is_template(candidate)) {
+      if (!templated_symbol(candidate)) {
         type_error(elabSpec->unqualifiedId->firstSourceLocation(),
                    std::format("expected a template"));
         return true;
@@ -11129,11 +11211,12 @@ void Parser::check(DeclarationAST* ast) {
   }
 }
 
-void Parser::check_init_declarator(InitDeclaratorAST* ast) {
+void Parser::check_init_declarator(InitDeclaratorAST* ast,
+                                   SpecifierAST* typeSpecifier) {
   TypeChecker check{unit_};
   check.setScope(scope());
   check.setReportErrors(config().checkTypes);
-  check.check_init_declarator(ast);
+  check.check_init_declarator(ast, typeSpecifier);
 
   if (!config().checkTypes) return;
   if (!ast || ast->initializer) return;

--- a/src/parser/cxx/parser.h
+++ b/src/parser/cxx/parser.h
@@ -34,7 +34,6 @@
 #include <functional>
 #include <optional>
 #include <unordered_map>
-#include <unordered_set>
 
 namespace cxx {
 class Decl;
@@ -69,6 +68,10 @@ class Parser final {
   struct UncheckedInitializerContext;
   struct CombinedScopeGuard;
   struct ExplicitTemplateHeadGuard;
+
+  enum class TypeNameContext { kGeneral, kTypeOnly };
+
+  enum class MemberAccessKind { kNone, kObject, kDependentObject };
 
   struct ScopeRAII {
     ScopeRAII(const ScopeRAII&) = delete;
@@ -191,9 +194,12 @@ class Parser final {
 
   [[nodiscard]] auto parse_id_expression(IdExpressionAST*& yyast,
                                          IdExpressionContext ctx) -> bool;
+  [[nodiscard]] auto objectAccessKind(ExpressionAST* objectExpression)
+      -> MemberAccessKind;
   [[nodiscard]] auto parse_unqualified_id(
       UnqualifiedIdAST*& yyast, NestedNameSpecifierAST* nestedNameSpecifier,
-      bool isTemplateIntroduced, bool inRequiresClause) -> bool;
+      bool isTemplateIntroduced, bool inRequiresClause,
+      MemberAccessKind memberAccess = MemberAccessKind::kNone) -> bool;
   void parse_optional_nested_name_specifier(NestedNameSpecifierAST*& yyast,
                                             NestedNameSpecifierContext ctx);
   [[nodiscard]] auto parse_nested_name_specifier(NestedNameSpecifierAST*& yyast,
@@ -473,10 +479,12 @@ class Parser final {
   [[nodiscard]] auto parse_empty_declaration(DeclarationAST*& yyast) -> bool;
   [[nodiscard]] auto parse_attribute_declaration(DeclarationAST*& yyast)
       -> bool;
-  [[nodiscard]] auto parse_decl_specifier(SpecifierAST*& yyast,
-                                          DeclSpecs& specs) -> bool;
-  [[nodiscard]] auto parse_decl_specifier_seq(List<SpecifierAST*>*& yyast,
-                                              DeclSpecs& specs) -> bool;
+  [[nodiscard]] auto parse_decl_specifier(
+      SpecifierAST*& yyast, DeclSpecs& specs,
+      TypeNameContext context = TypeNameContext::kGeneral) -> bool;
+  [[nodiscard]] auto parse_decl_specifier_seq(
+      List<SpecifierAST*>*& yyast, DeclSpecs& specs,
+      TypeNameContext context = TypeNameContext::kGeneral) -> bool;
   [[nodiscard]] auto parse_decl_specifier_seq_no_typespecs(
       List<SpecifierAST*>*& yyast, DeclSpecs& specs) -> bool;
   [[nodiscard]] auto parse_decl_specifier_seq_no_typespecs(
@@ -487,20 +495,25 @@ class Parser final {
                                               DeclSpecs& specs) -> bool;
   [[nodiscard]] auto parse_explicit_specifier(SpecifierAST*& yyast,
                                               DeclSpecs& specs) -> bool;
-  [[nodiscard]] auto parse_type_specifier(SpecifierAST*& yyast,
-                                          DeclSpecs& specs) -> bool;
-  [[nodiscard]] auto parse_type_specifier_seq(List<SpecifierAST*>*& yyast,
-                                              DeclSpecs& specs) -> bool;
+  [[nodiscard]] auto parse_type_specifier(
+      SpecifierAST*& yyast, DeclSpecs& specs,
+      TypeNameContext context = TypeNameContext::kGeneral) -> bool;
+  [[nodiscard]] auto parse_type_specifier_seq(
+      List<SpecifierAST*>*& yyast, DeclSpecs& specs,
+      TypeNameContext context = TypeNameContext::kGeneral) -> bool;
   void parse_optional_type_qualifier_seq(List<SpecifierAST*>*& yyast,
                                          DeclSpecs& specs);
-  [[nodiscard]] auto parse_defining_type_specifier(SpecifierAST*& yyast,
-                                                   DeclSpecs& specs) -> bool;
+  [[nodiscard]] auto parse_defining_type_specifier(
+      SpecifierAST*& yyast, DeclSpecs& specs,
+      TypeNameContext context = TypeNameContext::kGeneral) -> bool;
   [[nodiscard]] auto parse_defining_type_specifier_seq(
       List<SpecifierAST*>*& yyast, DeclSpecs& specs) -> bool;
-  [[nodiscard]] auto parse_simple_type_specifier(SpecifierAST*& yyast,
-                                                 DeclSpecs& specs) -> bool;
-  [[nodiscard]] auto parse_named_type_specifier(SpecifierAST*& yyast,
-                                                DeclSpecs& specs) -> bool;
+  [[nodiscard]] auto parse_simple_type_specifier(
+      SpecifierAST*& yyast, DeclSpecs& specs,
+      TypeNameContext context = TypeNameContext::kGeneral) -> bool;
+  [[nodiscard]] auto parse_named_type_specifier(
+      SpecifierAST*& yyast, DeclSpecs& specs,
+      TypeNameContext context = TypeNameContext::kGeneral) -> bool;
   [[nodiscard]] auto parse_decltype_specifier_type_specifier(
       SpecifierAST*& yyast, DeclSpecs& specs) -> bool;
   [[nodiscard]] auto parse_underlying_type_specifier(SpecifierAST*& yyast,
@@ -525,7 +538,7 @@ class Parser final {
 
   [[nodiscard]] auto parse_type_name(
       UnqualifiedIdAST*& yyast, NestedNameSpecifierAST* nestedNameSpecifier,
-      bool isTemplateIntroduced) -> bool;
+      bool isTemplateIntroduced, TypeNameContext context) -> bool;
   [[nodiscard]] auto parse_elaborated_type_specifier(SpecifierAST*& yyast,
                                                      DeclSpecs& specs) -> bool;
   [[nodiscard]] auto parse_elaborated_enum_specifier(SpecifierAST*& yyast,
@@ -585,14 +598,18 @@ class Parser final {
   [[nodiscard]] auto parse_cv_qualifier(SpecifierAST*& yyast,
                                         DeclSpecs& declSpecs) -> bool;
   [[nodiscard]] auto parse_ref_qualifier(SourceLocation& refLoc) -> bool;
-  [[nodiscard]] auto parse_type_id(TypeIdAST*& yyast) -> bool;
+  [[nodiscard]] auto parse_type_id(
+      TypeIdAST*& yyast, TypeNameContext context = TypeNameContext::kGeneral)
+      -> bool;
   [[nodiscard]] auto parse_defining_type_id(TypeIdAST*& yyast) -> bool;
   [[nodiscard]] auto parse_parameter_declaration_clause(
-      ParameterDeclarationClauseAST*& yyast) -> bool;
+      ParameterDeclarationClauseAST*& yyast,
+      TypeNameContext context = TypeNameContext::kGeneral) -> bool;
   [[nodiscard]] auto parse_parameter_declaration_list(
-      ParameterDeclarationClauseAST* ast) -> bool;
+      ParameterDeclarationClauseAST* ast, TypeNameContext context) -> bool;
   [[nodiscard]] auto parse_parameter_declaration(
-      ParameterDeclarationAST*& yyast, bool templParam) -> bool;
+      ParameterDeclarationAST*& yyast, bool templParam,
+      TypeNameContext context = TypeNameContext::kGeneral) -> bool;
   [[nodiscard]] auto parse_initializer(ExpressionAST*& yyast,
                                        const ExprContext& ctx) -> bool;
   [[nodiscard]] auto parse_brace_or_equal_initializer(ExpressionAST*& yyast)
@@ -626,6 +643,8 @@ class Parser final {
   [[nodiscard]] auto parse_enum_base(SourceLocation& colonLoc,
                                      List<SpecifierAST*>*& typeSpecifierList,
                                      DeclSpecs& specs) -> bool;
+  [[nodiscard]] auto enumeratorTypeInEnumSpecifier(Symbol* enumSymbol)
+      -> const Type*;
   void parse_enumerator_list(List<EnumeratorAST*>*& yyast, const Type* type);
   void parse_enumerator(EnumeratorAST*& yyast, const Type* type);
   [[nodiscard]] auto parse_using_enum_declaration(DeclarationAST*& yyast)
@@ -780,7 +799,9 @@ class Parser final {
       -> bool;
   [[nodiscard]] auto parse_simple_template_id(
       SimpleTemplateIdAST*& yyast, NestedNameSpecifierAST* nestedNameSpecifier,
-      bool isTemplateIntroduced = false) -> bool;
+      bool isTemplateIntroduced = false,
+      MemberAccessKind memberAccess = MemberAccessKind::kNone,
+      TypeNameContext context = TypeNameContext::kGeneral) -> bool;
   [[nodiscard]] auto parse_literal_operator_template_id(
       LiteralOperatorTemplateIdAST*& yyast,
       NestedNameSpecifierAST* nestedNameSpecifier) -> bool;
@@ -789,7 +810,8 @@ class Parser final {
       NestedNameSpecifierAST* nestedNameSpecifier) -> bool;
   [[nodiscard]] auto parse_template_id(
       UnqualifiedIdAST*& yyast, NestedNameSpecifierAST* nestedNameSpecifier,
-      bool isTemplateIntroduced) -> bool;
+      bool isTemplateIntroduced,
+      MemberAccessKind memberAccess = MemberAccessKind::kNone) -> bool;
   [[nodiscard]] auto parse_template_argument_list(
       List<TemplateArgumentAST*>*& yyast) -> bool;
   [[nodiscard]] auto parse_template_argument(TemplateArgumentAST*& yyast)
@@ -882,7 +904,8 @@ class Parser final {
 
   void check_bool_condition(ExpressionAST*& ast);
   void check_integral_condition(ExpressionAST*& ast);
-  void check_init_declarator(InitDeclaratorAST* initDecl);
+  void check_init_declarator(InitDeclaratorAST* initDecl,
+                             SpecifierAST* typeSpecifier);
   void check_mem_initializers(FunctionDefinitionAST* ast);
 
   [[nodiscard]] auto enterOrCreateNamespace(const Identifier* identifier,
@@ -893,16 +916,8 @@ class Parser final {
 
   void check_type_traits();
 
-  [[nodiscard]] auto is_template(Symbol* symbol) const -> bool;
-
   [[nodiscard]] auto evaluate_constant_expression(ExpressionAST* expr)
       -> std::optional<ConstValue>;
-
-  [[nodiscard]] auto maybe_template_name(const Identifier* id) -> bool;
-
-  void mark_maybe_template_name(const Identifier* id);
-  void mark_maybe_template_name(UnqualifiedIdAST* name);
-  void mark_maybe_template_name(DeclaratorAST* declarator);
 
   void synthesizeAbbreviatedTemplateParams(
       ParameterDeclarationClauseAST* params);
@@ -1012,8 +1027,5 @@ class Parser final {
 
   CachedAST<ParameterDeclarationClauseAST> parameter_declaration_clauses_;
   CachedAST<TemplateArgumentAST> template_arguments_;
-
-  std::unordered_set<const Identifier*> concept_names_;
-  std::unordered_set<const Identifier*> template_names_;
 };
 }  // namespace cxx

--- a/src/parser/cxx/standard_conversion.cc
+++ b/src/parser/cxx/standard_conversion.cc
@@ -1362,6 +1362,10 @@ auto StandardConversion::computeConversionSequence(
       traits.requireCompleteClass(destClass);
 
       for (auto ctor : destClass->convertingConstructors()) {
+        if (isExcludedInheritedConstructor(traits, ctor, destClass,
+                                           /*argCount=*/1))
+          continue;
+
         if (ctor->templateDeclaration() && !ctor->isSpecialization()) {
           auto args = make_list_node<ExpressionAST>(unit_->arena(), expr);
 

--- a/src/parser/cxx/substitution.cc
+++ b/src/parser/cxx/substitution.cc
@@ -257,10 +257,12 @@ auto Substitution::CollectRawTemplateArgument::operator()(
 
   auto interp = ASTInterpreter{unit};
 
-  auto value = interp.evaluate(expression);
+  const auto isDependent = isDependentTemplateArgument(subst.unit_, ast);
+
+  auto value = isDependent ? std::nullopt : interp.evaluate(expression);
 
   if (!value.has_value()) {
-    if (isDependentTemplateArgument(subst.unit_, ast)) {
+    if (isDependent) {
       auto expandedPattern = expression;
       if (auto packExpansion =
               ast_cast<PackExpansionExpressionAST>(expandedPattern)) {

--- a/src/parser/cxx/symbol_printer.cc
+++ b/src/parser/cxx/symbol_printer.cc
@@ -186,9 +186,9 @@ struct DumpSymbols {
       visit(*this, baseClass);
       --depth;
     }
-    if (!symbol->constructors().empty()) {
+    if (!symbol->declaredConstructors().empty()) {
       ++depth;
-      for (auto constructor : symbol->constructors()) {
+      for (auto constructor : symbol->declaredConstructors()) {
         if (constructor->canonical() != constructor) continue;
         visit(*this, constructor);
       }

--- a/src/parser/cxx/symbols.cc
+++ b/src/parser/cxx/symbols.cc
@@ -68,9 +68,12 @@ auto compare_symbols(Symbol* lhs, Symbol* rhs) -> bool {
 
   auto lhsVar = symbol_cast<VariableSymbol>(lhs);
   auto rhsVar = symbol_cast<VariableSymbol>(rhs);
-  if (lhsVar && rhsVar && lhsVar->constValue().has_value() &&
-      rhsVar->constValue().has_value()) {
-    if (lhsVar->constValue().value() != rhsVar->constValue().value()) {
+  if (lhsVar && rhsVar) {
+    if (lhsVar->constValue().has_value() != rhsVar->constValue().has_value())
+      return false;
+
+    if (lhsVar->constValue().has_value() &&
+        lhsVar->constValue().value() != rhsVar->constValue().value()) {
       return false;
     }
   }
@@ -207,6 +210,43 @@ auto template_name_symbol(Symbol* symbol) -> Symbol* {
   return nullptr;
 }
 
+auto templated_symbol(Symbol* symbol) -> Symbol* {
+  if (!symbol) return nullptr;
+
+  if (auto usingDeclaration = symbol_cast<UsingDeclarationSymbol>(symbol))
+    return templated_symbol(usingDeclaration->target());
+
+  if (auto overloadSet = symbol_cast<OverloadSetSymbol>(symbol)) {
+    for (auto function : overloadSet->functions()) {
+      if (auto result = templated_symbol(function)) return result;
+    }
+    return nullptr;
+  }
+
+  if (auto injected = symbol_cast<InjectedClassNameSymbol>(symbol)) {
+    auto classSymbol = injected->classSymbol();
+    if (!classSymbol) return nullptr;
+    if (auto primary = classSymbol->primaryTemplateSymbol())
+      classSymbol = primary;
+    return templated_symbol(classSymbol);
+  }
+
+  if (auto classSymbol = symbol_cast<ClassSymbol>(symbol)) {
+    if (classSymbol->isSpecialization())
+      return templated_symbol(classSymbol->primaryTemplateSymbol());
+  }
+
+  if (auto alias = symbol_cast<TypeAliasSymbol>(symbol)) {
+    if (alias->isSpecialization())
+      return templated_symbol(alias->primaryTemplateSymbol());
+  }
+
+  if (symbol_cast<TemplateTypeParameterSymbol>(symbol)) return symbol;
+  if (template_parameters_of(symbol) || template_declaration_of(symbol))
+    return symbol;
+  return nullptr;
+}
+
 auto Symbol::EnclosingSymbolIterator::operator++() -> EnclosingSymbolIterator& {
   symbol_ = symbol_->parent();
   return *this;
@@ -340,6 +380,42 @@ struct GetTemplateDeclaration {
   auto operator()(Symbol*) const -> TemplateDeclarationAST* { return nullptr; }
 };
 
+struct GetTemplateParameters {
+  template <Templatable S>
+  auto operator()(S* symbol) const -> TemplateParametersSymbol* {
+    return symbol->templateParameters();
+  }
+
+  auto operator()(Symbol*) const -> TemplateParametersSymbol* {
+    return nullptr;
+  }
+};
+
+struct GetTemplateDeclarationAST {
+  auto operator()(ClassSymbol* symbol) const -> AST* {
+    return symbol->declaration();
+  }
+
+  auto operator()(VariableSymbol* symbol) const -> AST* {
+    auto templateDeclaration = symbol->templateDeclaration();
+    return templateDeclaration ? templateDeclaration->declaration : nullptr;
+  }
+
+  auto operator()(TypeAliasSymbol* symbol) const -> AST* {
+    auto templateDeclaration = symbol->templateDeclaration();
+    return templateDeclaration ? templateDeclaration->declaration : nullptr;
+  }
+
+  auto operator()(FunctionSymbol* symbol) const -> AST* {
+    if (auto declaration = symbol->declaration()) return declaration;
+    if (auto templateDeclaration = symbol->templateDeclaration())
+      return templateDeclaration->declaration;
+    return nullptr;
+  }
+
+  auto operator()(Symbol*) const -> AST* { return nullptr; }
+};
+
 struct GetTemplateParameterInfo {
   auto operator()(TypeParameterSymbol* symbol) const
       -> std::optional<TypeParamInfo> {
@@ -382,6 +458,16 @@ struct GetTemplateParameterInfo {
 auto template_declaration_of(Symbol* symbol) -> TemplateDeclarationAST* {
   if (!symbol) return nullptr;
   return visit(GetTemplateDeclaration{}, symbol);
+}
+
+auto template_parameters_of(Symbol* symbol) -> TemplateParametersSymbol* {
+  if (!symbol) return nullptr;
+  return visit(GetTemplateParameters{}, symbol);
+}
+
+auto template_declaration_ast(Symbol* symbol) -> AST* {
+  if (!symbol) return nullptr;
+  return visit(GetTemplateDeclarationAST{}, symbol);
 }
 
 auto template_parameter_info(Symbol* symbol) -> std::optional<TypeParamInfo> {
@@ -683,7 +769,12 @@ void ClassSymbol::addBaseClass(BaseClassSymbol* baseClass) {
   baseClasses_.push_back(baseClass);
 }
 
-auto ClassSymbol::constructors() const -> const std::vector<FunctionSymbol*>& {
+auto ClassSymbol::constructors() const -> std::vector<FunctionSymbol*> {
+  return constructorOverloadSet_->functions();
+}
+
+auto ClassSymbol::declaredConstructors() const
+    -> const std::vector<FunctionSymbol*>& {
   return constructorOverloadSet_->declaredFunctions();
 }
 
@@ -975,6 +1066,10 @@ auto ClassSymbol::hasUserDeclaredConstructors() const -> bool {
     if (!ctor->isDefaulted()) return true;
   }
   return false;
+}
+
+auto ClassSymbol::hasInheritedConstructors() const -> bool {
+  return !constructorOverloadSet_->usingDeclarations().empty();
 }
 
 auto ClassSymbol::hasVirtualFunctions() const -> bool {
@@ -1630,20 +1725,14 @@ UsingDeclarationSymbol::~UsingDeclarationSymbol() {}
 
 auto UsingDeclarationSymbol::target() const -> Symbol* { return target_; }
 
-void UsingDeclarationSymbol::setTarget(Symbol* symbol) {
-  target_ = symbol;
-
-  introducedFunctions_.clear();
-  if (auto overloadSet = symbol_cast<OverloadSetSymbol>(symbol)) {
-    introducedFunctions_ = overloadSet->functions();
-  } else if (auto function = symbol_cast<FunctionSymbol>(symbol)) {
-    introducedFunctions_.push_back(function);
-  }
-}
+void UsingDeclarationSymbol::setTarget(Symbol* symbol) { target_ = symbol; }
 
 auto UsingDeclarationSymbol::introducedFunctions() const
-    -> const std::vector<FunctionSymbol*>& {
-  return introducedFunctions_;
+    -> std::vector<FunctionSymbol*> {
+  if (auto overloadSet = symbol_cast<OverloadSetSymbol>(target_))
+    return overloadSet->functions();
+  if (auto function = symbol_cast<FunctionSymbol>(target_)) return {function};
+  return {};
 }
 
 auto UsingDeclarationSymbol::declarator() const -> UsingDeclaratorAST* {

--- a/src/parser/cxx/symbols.h
+++ b/src/parser/cxx/symbols.h
@@ -75,8 +75,15 @@ struct PendingBodyInstantiation {
 
 [[nodiscard]] auto template_name_symbol(Symbol* symbol) -> Symbol*;
 
+[[nodiscard]] auto templated_symbol(Symbol* symbol) -> Symbol*;
+
 [[nodiscard]] auto template_declaration_of(Symbol* symbol)
     -> TemplateDeclarationAST*;
+
+[[nodiscard]] auto template_parameters_of(Symbol* symbol)
+    -> TemplateParametersSymbol*;
+
+[[nodiscard]] auto template_declaration_ast(Symbol* symbol) -> AST*;
 
 [[nodiscard]] auto is_member_template(Symbol* symbol) -> bool;
 
@@ -669,7 +676,9 @@ class ClassSymbol final : public ScopeSymbol,
 
   void addBaseClass(BaseClassSymbol* baseClass);
 
-  [[nodiscard]] auto constructors() const
+  [[nodiscard]] auto constructors() const -> std::vector<FunctionSymbol*>;
+
+  [[nodiscard]] auto declaredConstructors() const
       -> const std::vector<FunctionSymbol*>&;
 
   void addConstructor(FunctionSymbol* constructor);
@@ -700,6 +709,8 @@ class ClassSymbol final : public ScopeSymbol,
   [[nodiscard]] auto copyAssignmentOperator() const -> FunctionSymbol*;
   [[nodiscard]] auto moveAssignmentOperator() const -> FunctionSymbol*;
   [[nodiscard]] auto hasUserDeclaredConstructors() const -> bool;
+
+  [[nodiscard]] auto hasInheritedConstructors() const -> bool;
   [[nodiscard]] auto hasVirtualFunctions() const -> bool;
   [[nodiscard]] auto hasVirtualBaseClasses() const -> bool;
 
@@ -924,6 +935,13 @@ class FunctionSymbol final
   [[nodiscard]] auto vtableSlotIndex() const -> int { return vtableSlotIndex_; }
   void setVtableSlotIndex(int index) { vtableSlotIndex_ = index; }
 
+  [[nodiscard]] auto delegatingConstructor() const -> FunctionSymbol* {
+    return delegatingConstructor_;
+  }
+  void setDelegatingConstructor(FunctionSymbol* target) {
+    delegatingConstructor_ = target;
+  }
+
   [[nodiscard]] auto completeObjectVariant() const -> FunctionSymbol* {
     return completeObjectVariant_;
   }
@@ -949,6 +967,19 @@ class FunctionSymbol final
     return structorPrincipal_ != nullptr;
   }
 
+  [[nodiscard]] auto inheritedConstructor() const -> FunctionSymbol* {
+    return inheritedConstructor_;
+  }
+  [[nodiscard]] auto inheritedConstructorOrigin() const -> FunctionSymbol* {
+    auto origin = inheritedConstructor_;
+    while (origin && origin->inheritedConstructor_)
+      origin = origin->inheritedConstructor_;
+    return origin;
+  }
+  void setInheritedConstructor(FunctionSymbol* constructor) {
+    inheritedConstructor_ = constructor;
+  }
+
   [[nodiscard]] auto isDeletingDtorVariant() const -> bool {
     return structorPrincipal_ &&
            structorPrincipal_->deletingDtorVariant() == this;
@@ -957,8 +988,10 @@ class FunctionSymbol final
  private:
   std::unique_ptr<PendingBodyInstantiation> pendingBody_;
   FunctionSymbol* completeObjectVariant_ = nullptr;
+  FunctionSymbol* delegatingConstructor_ = nullptr;
   FunctionSymbol* deletingDtorVariant_ = nullptr;
   FunctionSymbol* structorPrincipal_ = nullptr;
+  FunctionSymbol* inheritedConstructor_ = nullptr;
   int vtableSlotIndex_ = -1;
   const Identifier* externalName_ = nullptr;
   const Identifier* aliasName_ = nullptr;
@@ -1098,8 +1131,15 @@ class TypeAliasSymbol final
   explicit TypeAliasSymbol(ScopeSymbol* enclosingScope);
   ~TypeAliasSymbol() override;
 
+  [[nodiscard]] auto expansionTypeId() const -> TypeIdAST* {
+    return expansionTypeId_;
+  }
+
+  void setExpansionTypeId(TypeIdAST* typeId) { expansionTypeId_ = typeId; }
+
  private:
   TemplateDeclarationAST* templateDeclaration_ = nullptr;
+  TypeIdAST* expansionTypeId_ = nullptr;
 };
 
 class VariableSymbol final
@@ -1332,10 +1372,28 @@ class ConstraintTypeParameterSymbol final : public Symbol {
   [[nodiscard]] auto isParameterPack() const -> bool;
   void setParameterPack(bool isParameterPack);
 
+  [[nodiscard]] auto typeConstraint() const -> TypeConstraintAST* {
+    return typeConstraint_;
+  }
+
+  void setTypeConstraint(TypeConstraintAST* typeConstraint) {
+    typeConstraint_ = typeConstraint;
+  }
+
+  [[nodiscard]] auto constraintExpression() const -> ExpressionAST* {
+    return constraintExpression_;
+  }
+
+  void setConstraintExpression(ExpressionAST* constraintExpression) {
+    constraintExpression_ = constraintExpression;
+  }
+
  private:
   int index_ = 0;
   int depth_ = 0;
   bool isParameterPack_ = false;
+  TypeConstraintAST* typeConstraint_ = nullptr;
+  ExpressionAST* constraintExpression_ = nullptr;
 };
 
 class EnumeratorSymbol final : public Symbol {
@@ -1366,12 +1424,11 @@ class UsingDeclarationSymbol final : public Symbol {
   void setTarget(Symbol* symbol);
 
   [[nodiscard]] auto introducedFunctions() const
-      -> const std::vector<FunctionSymbol*>&;
+      -> std::vector<FunctionSymbol*>;
 
  private:
   Symbol* target_ = nullptr;
   UsingDeclaratorAST* declarator_ = nullptr;
-  std::vector<FunctionSymbol*> introducedFunctions_;
 };
 
 bool is_type(Symbol* symbol);
@@ -1419,17 +1476,5 @@ inline auto symbol_cast(Symbol* symbol) -> ScopeSymbol* {
   return true;
 }
 
-[[nodiscard]] inline auto isEnclosedInTemplate(ScopeSymbol* scope) -> bool {
-  for (; scope; scope = scope->parent()) {
-    if (scope->isTemplateParameters()) return true;
-    if (auto cls = symbol_cast<ClassSymbol>(scope)) {
-      if (cls->templateParameters()) return true;
-    } else if (auto func = symbol_cast<FunctionSymbol>(scope)) {
-      if (func->templateParameters()) return true;
-    } else if (auto lambda = symbol_cast<LambdaSymbol>(scope)) {
-      if (lambda->isTemplate()) return true;
-    }
-  }
-  return false;
-}
+[[nodiscard]] auto isEnclosedInTemplate(ScopeSymbol* scope) -> bool;
 }  // namespace cxx

--- a/src/parser/cxx/template_argument_deduction.cc
+++ b/src/parser/cxx/template_argument_deduction.cc
@@ -83,6 +83,25 @@ auto TemplateArgumentDeduction::deduce(
   return buildTemplateArgumentList();
 }
 
+auto TemplateArgumentDeduction::deduceForGuide(
+    TemplateDeclarationAST* templateDecl, const FunctionType* functionType,
+    ParameterDeclarationClauseAST* parameters, List<ExpressionAST*>* args)
+    -> std::optional<List<TemplateArgumentAST*>*> {
+  if (!templateDecl || !functionType) return std::nullopt;
+
+  templateDecl_ = templateDecl;
+
+  collectTemplateParameters(templateDecl);
+
+  parameterDeclarations_ =
+      parameters ? parameters->parameterDeclarationList : nullptr;
+
+  if (!deduceFromCall(functionType, args)) return std::nullopt;
+  if (!checkDeducedArguments()) return std::nullopt;
+
+  return buildTemplateArgumentList();
+}
+
 auto TemplateArgumentDeduction::deduceFromConversionTarget(
     FunctionSymbol* func, const Type* targetType)
     -> std::optional<List<TemplateArgumentAST*>*> {
@@ -162,10 +181,19 @@ void TemplateArgumentDeduction::collectTemplateParameters(
     TemplateDeclarationAST* templateDecl) {
   templateParams_.clear();
 
+  int position = 0;
+
   for (auto p : ListView{templateDecl->templateParameterList}) {
     TemplateParameterInfo info;
+    info.depth = templateDecl->depth;
+    info.index = position++;
 
     if (auto sym = p->symbol) {
+      if (auto paramInfo = template_parameter_info(sym)) {
+        info.depth = paramInfo->depth;
+        info.index = paramInfo->index;
+      }
+
       info.typeParameterType = type_cast<TypeParameterType>(sym->type());
 
       if (auto typeParam = symbol_cast<TypeParameterSymbol>(sym)) {
@@ -210,6 +238,21 @@ void TemplateArgumentDeduction::collectTemplateParameters(
   deducedValues_.assign(n, std::nullopt);
   deducedPacks_.assign(n, {});
   deducedValuePacks_.assign(n, {});
+}
+
+auto TemplateArgumentDeduction::parameterSlot(int depth, int index) const
+    -> int {
+  for (std::size_t slot = 0; slot < templateParams_.size(); ++slot) {
+    const auto& info = templateParams_[slot];
+    if (info.depth == depth && info.index == index) return int(slot);
+  }
+  return -1;
+}
+
+auto TemplateArgumentDeduction::parameterSlot(
+    const TypeParameterType* type) const -> int {
+  if (!type) return -1;
+  return parameterSlot(type->depth(), type->index());
 }
 
 auto TemplateArgumentDeduction::substituteExplicitTemplateArguments(
@@ -313,8 +356,8 @@ auto TemplateArgumentDeduction::deduceTypeFromType(const Type* P, const Type* A)
                                      ? control_->getQualType(argElemBase, cvT)
                                      : argElemBase;
 
-          auto idx = elemTpt->index();
-          if (idx >= 0 && idx < static_cast<int>(templateParams_.size())) {
+          auto idx = parameterSlot(elemTpt);
+          if (idx >= 0) {
             if (!deducedTypes_[idx]) {
               deducedTypes_[idx] = deducedT;
             } else if (!traits.is_same(deducedTypes_[idx], deducedT)) {
@@ -353,8 +396,8 @@ auto TemplateArgumentDeduction::deduceTypeFromType(const Type* P, const Type* A)
     return true;
   }
 
-  auto idx = tpt->index();
-  if (idx < 0 || idx >= static_cast<int>(templateParams_.size())) return false;
+  auto idx = parameterSlot(tpt);
+  if (idx < 0) return false;
 
   const Type* deducedArg = A;
 
@@ -598,8 +641,8 @@ auto TemplateArgumentDeduction::deduceFromCall(const FunctionType* functionType,
       return false;
 
     auto bareParam = traits.remove_cvref(P);
-    auto tpt = type_cast<TypeParameterType>(bareParam);
-    if (!tpt || !templateParams_[tpt->index()].isPack) {
+    auto packSlot = parameterSlot(type_cast<TypeParameterType>(bareParam));
+    if (packSlot < 0 || !templateParams_[packSlot].isPack) {
       ++paramIt;
       if (paramDeclIt) paramDeclIt = paramDeclIt->next;
     }
@@ -616,13 +659,11 @@ auto TemplateArgumentDeduction::nonTypeParameterIndex(ExpressionAST* expr) const
   auto parameter = symbol_cast<NonTypeParameterSymbol>(idExpression->symbol);
   if (!parameter) return -1;
 
-  auto index = parameter->index();
-  if (index < 0 || index >= static_cast<int>(templateParams_.size())) return -1;
-
   auto info = template_parameter_info(parameter);
-  if (info && templateDecl_ && info->depth != templateDecl_->depth) return -1;
+  const int depth =
+      info ? info->depth : (templateDecl_ ? templateDecl_->depth : 0);
 
-  return index;
+  return parameterSlot(depth, parameter->index());
 }
 
 auto TemplateArgumentDeduction::deduceArrayBound(const Type* P, const Type* A)

--- a/src/parser/cxx/template_argument_deduction.h
+++ b/src/parser/cxx/template_argument_deduction.h
@@ -47,6 +47,8 @@ struct TemplateParameterInfo {
 
   const TypeParameterType* typeParameterType = nullptr;
   TemplateParameterAST* parameterAST = nullptr;
+  int depth = 0;
+  int index = 0;
   bool isPack = false;
   bool hasDefault = false;
   Kind kind = Kind::kUnknown;
@@ -58,6 +60,12 @@ class TemplateArgumentDeduction {
 
   [[nodiscard]] auto deduce(FunctionSymbol* func, List<ExpressionAST*>* args,
                             List<TemplateArgumentAST*>* explicitTemplateArgs)
+      -> std::optional<List<TemplateArgumentAST*>*>;
+
+  [[nodiscard]] auto deduceForGuide(TemplateDeclarationAST* templateDecl,
+                                    const FunctionType* functionType,
+                                    ParameterDeclarationClauseAST* parameters,
+                                    List<ExpressionAST*>* args)
       -> std::optional<List<TemplateArgumentAST*>*>;
 
   [[nodiscard]] auto deduceFromTargetType(FunctionSymbol* func,
@@ -129,6 +137,10 @@ class TemplateArgumentDeduction {
   [[nodiscard]] auto deduceArrayBound(const Type* P, const Type* A) -> bool;
 
   [[nodiscard]] auto nonTypeParameterIndex(ExpressionAST* expr) const -> int;
+
+  [[nodiscard]] auto parameterSlot(int depth, int index) const -> int;
+
+  [[nodiscard]] auto parameterSlot(const TypeParameterType* type) const -> int;
 
   TranslationUnit* unit_;
   TypeTraits traits;

--- a/src/parser/cxx/type_checker.cc
+++ b/src/parser/cxx/type_checker.cc
@@ -21,6 +21,7 @@
 #include <cxx/ast.h>
 #include <cxx/ast_interpreter.h>
 #include <cxx/ast_rewriter.h>
+#include <cxx/class_template_deduction.h>
 #include <cxx/control.h>
 #include <cxx/decl_specs.h>
 #include <cxx/dependent_types.h>
@@ -61,6 +62,17 @@ constexpr std::uintmax_t kMaximumAlignment = 1ULL << 32;
   if (name.empty()) return "the unnamed namespace";
 
   return std::format("namespace '{}'", name);
+}
+
+[[nodiscard]] auto delegationReaches(FunctionSymbol* target,
+                                     FunctionSymbol* origin) -> bool {
+  std::unordered_set<FunctionSymbol*> visited;
+  for (auto current = target; current;
+       current = current->delegatingConstructor()) {
+    if (current == origin) return true;
+    if (!visited.insert(current).second) return false;
+  }
+  return false;
 }
 
 [[nodiscard]] auto is_unresolved_id(ExpressionAST* expr) -> bool {
@@ -193,10 +205,11 @@ struct IsPotentiallyThrowing {
   }
 };
 
-[[nodiscard]] auto isPotentiallyThrowing(ExpressionAST* expr) -> bool {
+}  // namespace
+
+auto TypeChecker::isPotentiallyThrowing(ExpressionAST* expr) -> bool {
   return IsPotentiallyThrowing{}.apply(expr);
 }
-}  // namespace
 
 struct TypeChecker::Visitor {
   TypeChecker& check;
@@ -823,8 +836,7 @@ auto TypeChecker::Visitor::add_implicit_object_cv(const Type* fieldType,
   auto func = enclosing_function();
   if (!func) return fieldType;
 
-  auto funcClass =
-      symbol_cast<ClassSymbol>(func->enclosingNonTemplateParametersScope());
+  auto funcClass = symbol_cast<ClassSymbol>(func->parent());
 
   if (!funcClass) return fieldType;
   if (!traits.is_base_of(fieldClass->type(), funcClass->type()))
@@ -1300,36 +1312,32 @@ auto TypeChecker::Visitor::resolve_call_overload(
       }
     }
 
+    auto constraintsSatisfied =
+        ASTRewriter::evaluateAssociatedConstraints(check.unit_, func);
+    if (!constraintsSatisfied.has_value()) {
+      hasDependentTemplateCandidate = true;
+      continue;
+    }
+    if (!*constraintsSatisfied) {
+      reject(func, "constraints not satisfied");
+      continue;
+    }
+
     Candidate cand{func};
     cand.viable = true;
     cand.fromTemplate = templateCandidate;
     cand.deducedTemplateArgs = deducedArgsForCandidate;
 
-    if (isMemberCall && func->isImplicitObjectMemberFunction()) {
-      auto funcCv = type->cvQualifiers();
-      auto funcRef = type->refQualifier();
-
-      if (!cv_is_subset_of(objectCv, funcCv)) {
-        reject(func,
-               std::format("'this' argument has type '{}', but function is "
-                           "not marked {}",
-                           to_string(objectType),
-                           is_const(objectCv) ? "const" : "volatile"));
+    if (isMemberCall) {
+      auto objectConversion = resolution.implicitObjectArgumentConversion(
+          func, {.type = objectType,
+                 .cv = objectCv,
+                 .valueCategory = objectValueCategory});
+      if (!objectConversion) {
+        reject(func, objectConversion.error());
         continue;
       }
-
-      if (funcRef == RefQualifier::kLvalue &&
-          objectValueCategory == ValueCategory::kPrValue) {
-        reject(func, "expects an lvalue for the implicit object argument");
-        continue;
-      }
-      if (funcRef == RefQualifier::kRvalue &&
-          objectValueCategory == ValueCategory::kLValue) {
-        reject(func, "expects an rvalue for the implicit object argument");
-        continue;
-      }
-
-      cand.exactCvMatch = (objectCv == funcCv);
+      cand.objectConversion = *objectConversion;
     }
 
     auto paramIt = type->parameterTypes().begin();
@@ -1369,7 +1377,7 @@ auto TypeChecker::Visitor::resolve_call_overload(
   }
 
   auto [bestPtr, ambiguous] =
-      resolution.selectBestViableFunction(candidates, isMemberCall, true);
+      resolution.selectBestViableFunction(candidates, true);
 
   if (!bestPtr) {
     if (hasDependentTemplateCandidate) {
@@ -1487,20 +1495,12 @@ auto TypeChecker::Visitor::resolve_call_operator(CallExpressionAST* ast)
     Candidate cand{func};
     cand.viable = true;
 
-    if (!func->isStatic()) {
-      auto funcCv = type->cvQualifiers();
-      auto funcRef = type->refQualifier();
-
-      if (!cv_is_subset_of(objectCv, funcCv)) continue;
-      if (funcRef == RefQualifier::kLvalue &&
-          objectValueCategory == ValueCategory::kPrValue)
-        continue;
-      if (funcRef == RefQualifier::kRvalue &&
-          objectValueCategory == ValueCategory::kLValue)
-        continue;
-
-      cand.exactCvMatch = (objectCv == funcCv);
-    }
+    auto objectConversion = resolution.implicitObjectArgumentConversion(
+        func, {.type = baseType,
+               .cv = objectCv,
+               .valueCategory = objectValueCategory});
+    if (!objectConversion) continue;
+    cand.objectConversion = *objectConversion;
 
     auto paramIt = type->parameterTypes().begin();
     auto paramEnd = type->parameterTypes().end();
@@ -1564,7 +1564,7 @@ auto TypeChecker::Visitor::resolve_call_operator(CallExpressionAST* ast)
   }
 
   auto [bestPtr, ambiguous] =
-      resolution.selectBestViableFunction(viableCandidates, true, false);
+      resolution.selectBestViableFunction(viableCandidates);
 
   if (!bestPtr) return nullptr;
   if (ambiguous) {
@@ -1631,17 +1631,16 @@ auto TypeChecker::Visitor::resolve_arrow_operator(MemberExpressionAST* ast)
     Candidate cand{func};
     cand.viable = true;
 
-    if (!func->isStatic()) {
-      auto funcCv = type->cvQualifiers();
-      if (!cv_is_subset_of(objectCv, funcCv)) continue;
-      cand.exactCvMatch = (objectCv == funcCv);
-    }
+    auto objectConversion = resolution.implicitObjectArgumentConversion(
+        func, {.type = objectType, .cv = objectCv, .valueCategory = objectVC});
+    if (!objectConversion) continue;
+    cand.objectConversion = *objectConversion;
 
     viableCandidates.push_back(std::move(cand));
   }
 
   auto [bestPtr, ambiguous] =
-      resolution.selectBestViableFunction(viableCandidates, true, false);
+      resolution.selectBestViableFunction(viableCandidates);
   if (!bestPtr || ambiguous) return nullptr;
 
   auto operatorFunc = bestPtr->symbol;
@@ -2324,6 +2323,20 @@ void TypeChecker::Visitor::operator()(TypeConstructionAST* ast) {
     return;
   }
 
+  if (ClassTemplateArgumentDeduction::placeholderClassTemplate(
+          ast->typeSpecifier, check.scope())) {
+    std::vector<ExpressionAST*> arguments;
+    for (auto argument : ListView{ast->expressionList})
+      arguments.push_back(argument);
+
+    auto deduced = check.deduceClassTemplateSpecialization(
+        ast->typeSpecifier, arguments, /*isListInitialization=*/false,
+        /*isCopyInitialization=*/false, ast->lparenLoc);
+
+    if (!deduced) return;
+    ast->type = deduced;
+  }
+
   if (auto classType = type_cast<ClassType>(traits.remove_cv(ast->type))) {
     traits.requireCompleteClass(classType->symbol());
 
@@ -2372,6 +2385,20 @@ void TypeChecker::Visitor::operator()(BracedTypeConstructionAST* ast) {
             "excess elements in 'void' initializer");
     }
     return;
+  }
+
+  if (ClassTemplateArgumentDeduction::placeholderClassTemplate(
+          ast->typeSpecifier, check.scope())) {
+    std::vector<ExpressionAST*> arguments;
+    for (auto argument : ListView{ast->bracedInitList->expressionList})
+      arguments.push_back(argument);
+
+    auto deduced = check.deduceClassTemplateSpecialization(
+        ast->typeSpecifier, arguments, /*isListInitialization=*/true,
+        /*isCopyInitialization=*/false, ast->bracedInitList->lbraceLoc);
+
+    if (!deduced) return;
+    ast->type = deduced;
   }
 
   if (auto classType = type_cast<ClassType>(traits.remove_cv(ast->type))) {
@@ -3468,6 +3495,31 @@ void TypeChecker::Visitor::operator()(NoexceptExpressionAST* ast) {
 }
 
 void TypeChecker::Visitor::operator()(NewExpressionAST* ast) {
+  if (ClassTemplateArgumentDeduction::placeholderClassTemplate(
+          ast->typeSpecifierList ? ast->typeSpecifierList->value : nullptr,
+          check.scope())) {
+    std::vector<ExpressionAST*> arguments;
+    bool isListInitialization = false;
+
+    if (auto paren = ast_cast<NewParenInitializerAST>(ast->newInitalizer)) {
+      for (auto argument : ListView{paren->expressionList})
+        arguments.push_back(argument);
+    } else if (auto braced =
+                   ast_cast<NewBracedInitializerAST>(ast->newInitalizer);
+               braced && braced->bracedInitList) {
+      isListInitialization = true;
+      for (auto argument : ListView{braced->bracedInitList->expressionList})
+        arguments.push_back(argument);
+    }
+
+    auto deduced = check.deduceClassTemplateSpecialization(
+        ast->typeSpecifierList->value, arguments, isListInitialization,
+        /*isCopyInitialization=*/false, ast->newLoc);
+
+    if (!deduced) return;
+    ast->objectType = deduced;
+  }
+
   auto objectType = traits.remove_reference(ast->objectType);
 
   if (auto arrayType = type_cast<BoundedArrayType>(ast->objectType)) {
@@ -4540,8 +4592,7 @@ void TypeChecker::bind_template_parameter_base_initializers(
   auto functionSymbol = symbol_cast<FunctionSymbol>(scope_);
   if (!functionSymbol || !functionSymbol->isConstructor()) return;
 
-  auto classSymbol = symbol_cast<ClassSymbol>(
-      functionSymbol->enclosingNonTemplateParametersScope());
+  auto classSymbol = symbol_cast<ClassSymbol>(functionSymbol->parent());
   if (!classSymbol) return;
 
   auto control = unit_->control();
@@ -4576,8 +4627,7 @@ void TypeChecker::check_mem_initializers(
 
   if (!functionSymbol->isConstructor()) return;
 
-  auto classSymbol = symbol_cast<ClassSymbol>(
-      functionSymbol->enclosingNonTemplateParametersScope());
+  auto classSymbol = symbol_cast<ClassSymbol>(functionSymbol->parent());
   if (!classSymbol) return;
 
   auto control = unit_->control();
@@ -4611,6 +4661,27 @@ void TypeChecker::check_mem_initializers(
                                        ValueCategory::kPrValue, nullptr);
   };
 
+  auto completeResolvedConstructorCall = [&](MemInitializerAST* memInit) {
+    auto parameters = StandardConversion::parameters(memInit->constructor);
+    auto args = collectArgs(memInit);
+
+    for (size_t i = 0; i < args.size() && i < parameters.size(); ++i)
+      (void)implicit_conversion(*args[i], parameters[i]->type());
+
+    if (args.size() >= parameters.size()) return;
+
+    List<ExpressionAST*>** tail = nullptr;
+    if (auto paren = ast_cast<ParenMemInitializerAST>(memInit))
+      tail = &paren->expressionList;
+    else if (auto braced = ast_cast<BracedMemInitializerAST>(memInit);
+             braced && braced->bracedInitList)
+      tail = &braced->bracedInitList->expressionList;
+    if (!tail) return;
+
+    while (*tail) tail = &(*tail)->next;
+    append_default_arguments(memInit->constructor, tail);
+  };
+
   for (auto memInit : ListView{ast->memInitializerList}) {
     UnqualifiedIdAST* unqualifiedId = nullptr;
     if (auto paren = ast_cast<ParenMemInitializerAST>(memInit))
@@ -4620,6 +4691,7 @@ void TypeChecker::check_mem_initializers(
 
     if (!unqualifiedId) {
       if (memInit->symbol) explicitlyInitialized.insert(memInit->symbol);
+      if (memInit->constructor) completeResolvedConstructorCall(memInit);
       continue;
     }
 
@@ -4657,11 +4729,13 @@ void TypeChecker::check_mem_initializers(
         continue;
       }
 
-      if (resolution.best->symbol == functionSymbol) {
+      if (delegationReaches(resolution.best->symbol, functionSymbol)) {
         error(memInit->firstSourceLocation(),
               "constructor delegates to itself");
         continue;
       }
+
+      functionSymbol->setDelegatingConstructor(resolution.best->symbol);
 
       memInit->symbol = classSymbol;
       memInit->constructor = resolution.best->symbol;
@@ -4767,10 +4841,14 @@ void TypeChecker::check_mem_initializers(
                braced && braced->bracedInitList)
         memInitArguments = &braced->bracedInitList->expressionList;
 
-      ExpressionAST* initializer = memInitializerClause(memInit);
-      memInit->constructor = check_class_initializer(
-          targetType, initializer, memInit->firstSourceLocation(),
-          memInitArguments);
+      if (memInit->constructor) {
+        completeResolvedConstructorCall(memInit);
+      } else {
+        ExpressionAST* initializer = memInitializerClause(memInit);
+        memInit->constructor = check_class_initializer(
+            targetType, initializer, memInit->firstSourceLocation(),
+            memInitArguments);
+      }
     } else if (unit_->typeTraits().is_array(targetType)) {
       auto braced = ast_cast<BracedMemInitializerAST>(memInit);
       auto paren = ast_cast<ParenMemInitializerAST>(memInit);

--- a/src/parser/cxx/type_checker.h
+++ b/src/parser/cxx/type_checker.h
@@ -64,7 +64,8 @@ class TypeChecker {
 
   auto check_bool_condition(ExpressionAST*& ast) -> bool;
   void check_integral_condition(ExpressionAST*& ast);
-  void check_init_declarator(InitDeclaratorAST* initDecl);
+  void check_init_declarator(InitDeclaratorAST* initDecl,
+                             SpecifierAST* typeSpecifier);
   void check_condition_declaration(ConditionExpressionAST* ast);
   void check_field_initializer(FieldSymbol* field);
   void check_mem_initializers(CompoundStatementFunctionBodyAST* ast);
@@ -83,9 +84,16 @@ class TypeChecker {
   [[nodiscard]] auto deduceAutoType(const Type* declaredType,
                                     const Type* initializerType) -> const Type*;
 
+  [[nodiscard]] static auto isPotentiallyThrowing(ExpressionAST* expr) -> bool;
+
   [[nodiscard]] auto deducePlaceholderType(const Type* declaredType,
                                            ExpressionAST* initializer)
       -> const Type*;
+
+  [[nodiscard]] auto deduceClassTemplateSpecialization(
+      SpecifierAST* typeSpecifier, const std::vector<ExpressionAST*>& arguments,
+      bool isListInitialization, bool isCopyInitialization,
+      SourceLocation location) -> const Type*;
 
   auto getInitDeclaratorLocation(InitDeclaratorAST* ast,
                                  VariableSymbol* var) const -> SourceLocation;

--- a/src/parser/cxx/type_checker_initializer.cc
+++ b/src/parser/cxx/type_checker_initializer.cc
@@ -20,6 +20,7 @@
 
 #include <cxx/ast.h>
 #include <cxx/ast_interpreter.h>
+#include <cxx/class_template_deduction.h>
 #include <cxx/control.h>
 #include <cxx/dependent_types.h>
 #include <cxx/literals.h>
@@ -294,19 +295,15 @@ struct NarrowingChecker {
                                                  const Type* targetType)
       -> bool {
     if (!ctx.traits.is_floating_point(targetType)) return false;
-    if (!std::isfinite(value)) return false;
 
-    if (type_cast<FloatType>(targetType)) {
-      auto conv = static_cast<float>(value);
-      return std::isfinite(conv) && static_cast<double>(conv) == value;
-    }
-    if (type_cast<DoubleType>(targetType)) return true;
-    if (type_cast<LongDoubleType>(targetType)) {
-      auto conv = static_cast<long double>(value);
-      return std::isfinite(static_cast<double>(conv)) &&
-             static_cast<double>(conv) == value;
-    }
-    return false;
+    const bool convertedIsFinite =
+        type_cast<FloatType>(targetType)
+            ? std::isfinite(static_cast<float>(value))
+            : std::isfinite(static_cast<long double>(value));
+
+    if (!std::isfinite(value)) return !convertedIsFinite;
+
+    return convertedIsFinite;
   }
 };
 
@@ -1013,6 +1010,8 @@ struct ClassInitChecker {
   void checkConstructorInit(Target& target, ClassSymbol* classSymbol,
                             bool diagnoseUnresolved);
 
+  void reportRejectedConstructors(const ConstructorResult& resolution);
+
   void appendDefaultArguments(Target& target, FunctionSymbol* constructor);
 
   [[nodiscard]] auto arguments(Target& target) -> std::vector<ExpressionAST*>;
@@ -1129,6 +1128,11 @@ void ClassInitChecker::checkConstructorInit(Target& target,
   OverloadResolution overloadRes(ctx.unit);
   auto resolution = overloadRes.resolveConstructor(classSymbol, args);
 
+  auto location = target.location;
+  if (!location && target.initializer)
+    location = target.initializer->firstSourceLocation();
+  if (!location) location = classSymbol->location();
+
   auto bracedInitList = InitUnwrapper::getBracedInitList(target.initializer);
   if (bracedInitList &&
       tryInitializerListConstructor(target, bracedInitList, classSymbol,
@@ -1136,13 +1140,23 @@ void ClassInitChecker::checkConstructorInit(Target& target,
     return;
 
   if (!resolution.best) {
-    if (diagnoseUnresolved)
-      ctx.error(target.location, "no matching constructor");
+    if (diagnoseUnresolved) {
+      ctx.error(
+          location,
+          std::format("no matching constructor for initialization of '{}'",
+                      to_string(classSymbol->type())));
+      reportRejectedConstructors(resolution);
+    }
     return;
   }
 
   if (resolution.ambiguous) {
-    ctx.error(target.location, "constructor call is ambiguous");
+    ctx.error(location, std::format("call to constructor of '{}' is ambiguous",
+                                    to_string(classSymbol->type())));
+    for (const auto& candidate : resolution.candidates) {
+      if (!candidate.viable || !candidate.symbol) continue;
+      ctx.checker.note(candidate.symbol->location(), "candidate constructor");
+    }
     return;
   }
 
@@ -1150,6 +1164,23 @@ void ClassInitChecker::checkConstructorInit(Target& target,
   ctx.checker.reportDeletedFunction(target.constructor, target.location);
   applyArgumentConversions(target, resolution.best->conversions);
   appendDefaultArguments(target, target.constructor);
+}
+
+void ClassInitChecker::reportRejectedConstructors(
+    const ConstructorResult& resolution) {
+  std::vector<std::pair<SourceLocation, std::string>> reported;
+
+  for (const auto& [symbol, reason] : resolution.rejected) {
+    if (!symbol) continue;
+
+    std::pair entry{symbol->location(), reason};
+    if (std::ranges::contains(reported, entry)) continue;
+    reported.push_back(entry);
+
+    ctx.checker.note(
+        symbol->location(),
+        std::format("candidate constructor not viable: {}", reason));
+  }
 }
 
 auto ClassInitChecker::arguments(Target& target)
@@ -1370,6 +1401,8 @@ struct TypeDeducer {
 
   void deduceArraySize(VariableSymbol* var);
   void deduceAutoType(VariableSymbol* var);
+  void deduceClassTemplateArguments(VariableSymbol* var,
+                                    SpecifierAST* typeSpecifier);
 
  private:
   void deduceArraySizeFromBraced(VariableSymbol* var,
@@ -1488,6 +1521,32 @@ static auto deduceCompoundAuto(InitContext& ctx, const Type* P, const Type* A)
   return nullptr;
 }
 
+void TypeDeducer::deduceClassTemplateArguments(VariableSymbol* var,
+                                               SpecifierAST* typeSpecifier) {
+  if (!ClassTemplateArgumentDeduction::placeholderClassTemplate(
+          typeSpecifier, ctx.checker.scope()))
+    return;
+
+  auto initializer = var->initializer();
+
+  const auto initializationKind =
+      InitUnwrapper::initializationKind(initializer);
+
+  auto deduced = ctx.checker.deduceClassTemplateSpecialization(
+      typeSpecifier, InitUnwrapper::collectArgs(initializer),
+      InitUnwrapper::getBracedInitList(initializer) != nullptr,
+      initializationKind == InitializationKind::kCopyInitialization ||
+          initializationKind == InitializationKind::kCopyListInitialization,
+      var->location());
+
+  if (!deduced) return;
+
+  const auto cvQualifiers = ctx.traits.get_cv_qualifiers(var->type());
+  var->setType(cvQualifiers != CvQualifiers::kNone
+                   ? ctx.control->getQualType(deduced, cvQualifiers)
+                   : deduced);
+}
+
 void TypeDeducer::deduceAutoType(VariableSymbol* var) {
   auto declType = var->type();
   if (!containsPlaceholderType(declType)) return;
@@ -1594,9 +1653,10 @@ struct InitDeclaratorChecker {
         typeDeducer{ctx},
         constexprEval{ctx} {}
 
-  void checkInitDeclarator(InitDeclaratorAST* ast);
+  void checkInitDeclarator(InitDeclaratorAST* ast, SpecifierAST* typeSpecifier);
   void checkVariable(VariableSymbol* var, ExpressionAST*& initializer,
-                     SourceLocation location);
+                     SourceLocation location,
+                     SpecifierAST* typeSpecifier = nullptr);
   void checkBracedInitList(const Type* type, BracedInitListAST* ast,
                            InitializationKind initializationKind);
   void checkFieldInitializer(FieldSymbol* field);
@@ -1612,20 +1672,23 @@ struct InitDeclaratorChecker {
   void evaluateConstValue(VariableSymbol* var);
 };
 
-void InitDeclaratorChecker::checkInitDeclarator(InitDeclaratorAST* ast) {
+void InitDeclaratorChecker::checkInitDeclarator(InitDeclaratorAST* ast,
+                                                SpecifierAST* typeSpecifier) {
   auto var = symbol_cast<VariableSymbol>(ast->symbol);
   if (!var) return;
 
   checkVariable(var, ast->initializer,
-                ctx.checker.getInitDeclaratorLocation(ast, var));
+                ctx.checker.getInitDeclaratorLocation(ast, var), typeSpecifier);
 }
 
 void InitDeclaratorChecker::checkVariable(VariableSymbol* var,
                                           ExpressionAST*& initializer,
-                                          SourceLocation location) {
+                                          SourceLocation location,
+                                          SpecifierAST* typeSpecifier) {
   var->setInitializer(initializer);
 
   typeDeducer.deduceArraySize(var);
+  typeDeducer.deduceClassTemplateArguments(var, typeSpecifier);
   typeDeducer.deduceAutoType(var);
 
   if (var->isConstexpr()) var->setType(ctx.traits.add_const(var->type()));
@@ -1744,7 +1807,8 @@ void InitDeclaratorChecker::evaluateConstValue(VariableSymbol* var) {
   }
 
   if (var->isConstexpr() && !var->constValue().has_value()) {
-    auto dep = isDependent(ctx.unit, var->type());
+    auto dep = var->templateParameters() != nullptr;
+    if (!dep) dep = isDependent(ctx.unit, var->type());
     if (!dep && var->initializer())
       dep = isDependent(ctx.unit, var->initializer());
     if (!dep)
@@ -1753,8 +1817,9 @@ void InitDeclaratorChecker::evaluateConstValue(VariableSymbol* var) {
 }
 }  // namespace
 
-void TypeChecker::check_init_declarator(InitDeclaratorAST* ast) {
-  InitDeclaratorChecker{*this}.checkInitDeclarator(ast);
+void TypeChecker::check_init_declarator(InitDeclaratorAST* ast,
+                                        SpecifierAST* typeSpecifier) {
+  InitDeclaratorChecker{*this}.checkInitDeclarator(ast, typeSpecifier);
 }
 
 void TypeChecker::check_condition_declaration(ConditionExpressionAST* ast) {
@@ -1807,5 +1872,47 @@ auto TypeChecker::check_class_initializer(const Type* targetType,
     -> FunctionSymbol* {
   return InitDeclaratorChecker{*this}.checkClassInitializer(
       targetType, initializer, location, argumentList);
+}
+
+auto TypeChecker::deduceClassTemplateSpecialization(
+    SpecifierAST* typeSpecifier, const std::vector<ExpressionAST*>& arguments,
+    bool isListInitialization, bool isCopyInitialization,
+    SourceLocation location) -> const Type* {
+  auto primaryTemplate =
+      ClassTemplateArgumentDeduction::placeholderClassTemplate(typeSpecifier,
+                                                               scope_);
+  if (!primaryTemplate) return nullptr;
+
+  for (auto argument : arguments) {
+    if (!argument || !argument->type) return nullptr;
+    if (isDependent(unit_, argument->type)) return nullptr;
+  }
+
+  ClassTemplateArgumentDeduction::Initializer initializer{
+      .arguments = arguments,
+      .isListInitialization = isListInitialization,
+      .isCopyInitialization = isCopyInitialization};
+
+  ClassTemplateArgumentDeduction deduction{unit_};
+  auto deduced =
+      deduction.deduce(primaryTemplate, initializer, location, scope_);
+
+  if (!deduced) {
+    if (deduction.selectedExplicitOnly()) {
+      error(
+          location,
+          std::format("class template argument deduction for '{}' selected an "
+                      "explicit deduction guide for copy-list-initialization",
+                      to_string(primaryTemplate->name())));
+    } else {
+      error(location,
+            std::format("no viable constructor or deduction guide for "
+                        "deduction of template arguments of '{}'",
+                        to_string(primaryTemplate->name())));
+    }
+    return nullptr;
+  }
+
+  return deduced->type();
 }
 }  // namespace cxx

--- a/src/parser/cxx/type_traits.cc
+++ b/src/parser/cxx/type_traits.cc
@@ -23,6 +23,7 @@
 #include <cxx/control.h>
 #include <cxx/memory_layout.h>
 #include <cxx/names.h>
+#include <cxx/overload_resolution.h>
 #include <cxx/standard_conversion.h>
 #include <cxx/symbols.h>
 #include <cxx/translation_unit.h>
@@ -1408,6 +1409,12 @@ auto TypeTraits::is_base_of(const Type* base, const Type* derived) const
   return derivedClassType->symbol()->hasBaseClass(baseClassType->symbol());
 }
 
+auto TypeTraits::is_reference_related(const Type* lhs, const Type* rhs) const
+    -> bool {
+  if (is_same(remove_cv(lhs), remove_cv(rhs))) return true;
+  return is_base_of(lhs, rhs);
+}
+
 auto TypeTraits::is_virtual_base_of(const Type* base, const Type* derived) const
     -> bool {
   auto baseClassType = type_cast<ClassType>(remove_cv(base));
@@ -1513,6 +1520,7 @@ auto TypeTraits::is_aggregate(const Type* type) -> bool {
   requireCompleteClass(cls);
   if (!cls || !cls->isComplete()) return false;
   if (cls->hasUserDeclaredConstructors()) return false;
+  if (cls->hasInheritedConstructors()) return false;
   if (cls->hasVirtualFunctions()) return false;
   if (cls->hasVirtualBaseClasses()) return false;
   return true;
@@ -1553,6 +1561,26 @@ auto TypeTraits::is_final(const Type* type) -> bool {
   auto cls = classType->definition();
   if (!cls) return false;
   return cls->isFinal();
+}
+
+auto TypeTraits::selectConstructor(ClassSymbol* classSymbol,
+                                   std::span<const Type* const> argTypes)
+    -> FunctionSymbol* {
+  std::vector<ExpressionAST*> args;
+  args.reserve(argTypes.size());
+
+  for (auto argType : argTypes) {
+    if (!argType) return nullptr;
+    const auto valueCategory = is_lvalue_reference(argType)
+                                   ? ValueCategory::kLValue
+                                   : ValueCategory::kXValue;
+    args.push_back(ThisExpressionAST::create(unit_->arena(), valueCategory,
+                                             remove_reference(argType)));
+  }
+
+  auto result = OverloadResolution{unit_}.resolveConstructor(classSymbol, args);
+  if (result.ambiguous || !result.best) return nullptr;
+  return result.best->symbol;
 }
 
 auto TypeTraits::is_constructible(const Type* type,
@@ -1602,17 +1630,8 @@ auto TypeTraits::is_constructible(const Type* type,
       }
     }
 
-    for (auto ctor : cls->constructors()) {
-      if (ctor->isDeleted()) continue;
-      auto ctorType = type_cast<FunctionType>(ctor->type());
-      if (!ctorType) continue;
-      auto params = ctorType->parameterTypes();
-      if (params.size() == argTypes.size()) return true;
-      if (ctorType->isVariadic() && params.size() <= argTypes.size())
-        return true;
-    }
-
-    return false;
+    auto selected = selectConstructor(cls, argTypes);
+    return selected && !selected->isDeleted();
   }
 
   if (is_void(unqual)) return false;
@@ -1679,17 +1698,10 @@ auto TypeTraits::is_nothrow_constructible(const Type* type,
       }
     }
 
-    for (auto ctor : cls->constructors()) {
-      if (ctor->isDeleted()) continue;
-      auto ctorType = type_cast<FunctionType>(ctor->type());
-      if (!ctorType) continue;
-      auto params = ctorType->parameterTypes();
-      if (params.size() == argTypes.size()) return ctorType->isNoexcept();
-      if (ctorType->isVariadic() && params.size() <= argTypes.size())
-        return ctorType->isNoexcept();
-    }
-
-    return false;
+    auto selected = selectConstructor(cls, argTypes);
+    if (!selected || selected->isDeleted()) return false;
+    auto ctorType = type_cast<FunctionType>(selected->type());
+    return ctorType && ctorType->isNoexcept();
   }
 
   return false;

--- a/src/parser/cxx/type_traits.h
+++ b/src/parser/cxx/type_traits.h
@@ -29,6 +29,7 @@ namespace cxx {
 class ClassSymbol;
 class Control;
 class ExpressionAST;
+class FunctionSymbol;
 class TranslationUnit;
 class Type;
 
@@ -129,6 +130,9 @@ class TypeTraits {
   [[nodiscard]] auto is_base_of(const Type* base, const Type* derived) const
       -> bool;
 
+  [[nodiscard]] auto is_reference_related(const Type* lhs,
+                                          const Type* rhs) const -> bool;
+
   [[nodiscard]] auto is_virtual_base_of(const Type* base,
                                         const Type* derived) const -> bool;
   [[nodiscard]] auto is_convertible(const Type* from, const Type* to) const
@@ -142,6 +146,9 @@ class TypeTraits {
   auto is_empty(const Type* type) -> bool;
   auto is_polymorphic(const Type* type) -> bool;
   auto is_final(const Type* type) -> bool;
+  auto selectConstructor(ClassSymbol* classSymbol,
+                         std::span<const Type* const> argTypes)
+      -> FunctionSymbol*;
   auto is_constructible(const Type* type, std::span<const Type* const> argTypes)
       -> bool;
   auto is_nothrow_constructible(const Type* type,

--- a/src/parser/cxx/views/symbols.h
+++ b/src/parser/cxx/views/symbols.h
@@ -72,6 +72,9 @@ inline auto members(ScopeSymbol* symbol) {
   return std::views::all(symbol->members());
 }
 
+constexpr auto parameters = std::views::filter(&Symbol::isParameter) |
+                            std::views::transform(symbol_cast<ParameterSymbol>);
+
 constexpr auto named_symbol = std::views::filter(&Symbol::name);
 
 constexpr auto fields = std::views::filter(&Symbol::isField) |

--- a/tests/api_tests/test_utils.h
+++ b/tests/api_tests/test_utils.h
@@ -54,7 +54,6 @@ struct Source {
 
     unit.parse({
         .checkTypes = true,
-        .fuzzyTemplateResolution = false,
         .templateInstantiation = templateInstantiation,
         .reflect = true,
     });

--- a/tests/unit_tests/ast/access_declaration_01.cc
+++ b/tests/unit_tests/ast/access_declaration_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 class SimpleClass {
  private:

--- a/tests/unit_tests/ast/array_to_pointer_conv_01.cc
+++ b/tests/unit_tests/ast/array_to_pointer_conv_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s
 
 auto main() -> int {
   int a[10];

--- a/tests/unit_tests/ast/asm_declaration_01.cc
+++ b/tests/unit_tests/ast/asm_declaration_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 void asm_qualifiers() {
   asm("nop");

--- a/tests/unit_tests/ast/binary_expression_01.cc
+++ b/tests/unit_tests/ast/binary_expression_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 int a = 10;
 int b = 20;

--- a/tests/unit_tests/ast/bitfield_declaration_01.cc
+++ b/tests/unit_tests/ast/bitfield_declaration_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 struct Bits {
   int value : 32;

--- a/tests/unit_tests/ast/bool_literals_01.cc
+++ b/tests/unit_tests/ast/bool_literals_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 const bool ok = true;
 const bool ko = false;

--- a/tests/unit_tests/ast/boolean_conv_01.cc
+++ b/tests/unit_tests/ast/boolean_conv_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s
 
 auto main() -> int {
   void* ptr;

--- a/tests/unit_tests/ast/class_definition_01.cc
+++ b/tests/unit_tests/ast/class_definition_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 class EmptyClass {};
 

--- a/tests/unit_tests/ast/complex_type_specifier_01.cc
+++ b/tests/unit_tests/ast/complex_type_specifier_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 __complex__ float a;
 __complex__ double b;

--- a/tests/unit_tests/ast/consteval_if_01.cc
+++ b/tests/unit_tests/ast/consteval_if_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 auto main() -> int {
   if consteval {

--- a/tests/unit_tests/ast/constrained_template_parameter_01.cc
+++ b/tests/unit_tests/ast/constrained_template_parameter_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 template <typename T>
 concept Any = true;

--- a/tests/unit_tests/ast/ctor_initializer_01.cc
+++ b/tests/unit_tests/ast/ctor_initializer_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 struct Handle {
   int zero_;

--- a/tests/unit_tests/ast/deduce_this_01.cc
+++ b/tests/unit_tests/ast/deduce_this_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 template <typename T>
 concept ok = true;

--- a/tests/unit_tests/ast/deduction_guide_01.cc
+++ b/tests/unit_tests/ast/deduction_guide_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 template <typename T>
 struct List {

--- a/tests/unit_tests/ast/deduction_guide_02.cc
+++ b/tests/unit_tests/ast/deduction_guide_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 struct List {
   template <typename T>

--- a/tests/unit_tests/ast/designated_initializer_01.cc
+++ b/tests/unit_tests/ast/designated_initializer_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 struct Pair {
   int first;

--- a/tests/unit_tests/ast/enum_definition_01.cc
+++ b/tests/unit_tests/ast/enum_definition_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 enum Kind {
   k1,

--- a/tests/unit_tests/ast/equal_initializer_01.cc
+++ b/tests/unit_tests/ast/equal_initializer_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 const int values[] = {
     1,

--- a/tests/unit_tests/ast/floating_integral_conv_01.cc
+++ b/tests/unit_tests/ast/floating_integral_conv_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s
 
 void f(int a, int b);
 

--- a/tests/unit_tests/ast/floating_point_conv_01.cc
+++ b/tests/unit_tests/ast/floating_point_conv_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s
 
 void f(int a, int b);
 

--- a/tests/unit_tests/ast/floating_point_promotion_01.cc
+++ b/tests/unit_tests/ast/floating_point_promotion_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s
 
 void f(int a, int b);
 

--- a/tests/unit_tests/ast/for_range_statement_01.cc
+++ b/tests/unit_tests/ast/for_range_statement_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 int main() {
   for (int i : {10, 20, 30}) {

--- a/tests/unit_tests/ast/for_range_statement_02.cc
+++ b/tests/unit_tests/ast/for_range_statement_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 int main() {
   int map[][2] = {{1, 2}};

--- a/tests/unit_tests/ast/function_definition_01.cc
+++ b/tests/unit_tests/ast/function_definition_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 void (*ptr)(){};
 

--- a/tests/unit_tests/ast/function_to_pointer_conv_01.cc
+++ b/tests/unit_tests/ast/function_to_pointer_conv_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s
 
 void f(int a, int b);
 

--- a/tests/unit_tests/ast/generic_selection_01.c
+++ b/tests/unit_tests/ast/generic_selection_01.c
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 // clang-format on
 
 int main() {

--- a/tests/unit_tests/ast/if_statement_01.cc
+++ b/tests/unit_tests/ast/if_statement_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 auto main() -> int {
   if (false)

--- a/tests/unit_tests/ast/integral_conversion_01.cc
+++ b/tests/unit_tests/ast/integral_conversion_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s
 
 void f(int a, int b);
 

--- a/tests/unit_tests/ast/integral_promotion_conv_01.cc
+++ b/tests/unit_tests/ast/integral_promotion_conv_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s
 
 void f(int a, int b);
 

--- a/tests/unit_tests/ast/lambda_specifier_01.cc
+++ b/tests/unit_tests/ast/lambda_specifier_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 auto main() -> int {
   auto consteval_lambda = []() consteval { return 0; };

--- a/tests/unit_tests/ast/namespace_definition_01.cc
+++ b/tests/unit_tests/ast/namespace_definition_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 namespace {}
 

--- a/tests/unit_tests/ast/nested_templates_01.cc
+++ b/tests/unit_tests/ast/nested_templates_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 template <typename T, typename A>
 class List {

--- a/tests/unit_tests/ast/new_expression_01.cc
+++ b/tests/unit_tests/ast/new_expression_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 template <typename T>
 auto make(void* where, T init) {

--- a/tests/unit_tests/ast/pack_expansion_01.cc
+++ b/tests/unit_tests/ast/pack_expansion_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 void foo() {}
 

--- a/tests/unit_tests/ast/parameter_pack_01.cc
+++ b/tests/unit_tests/ast/parameter_pack_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 void func(auto... args);
 

--- a/tests/unit_tests/ast/reflect_01.cc
+++ b/tests/unit_tests/ast/reflect_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s
 // clang-format on
 
 constexpr auto int_ty = ^^int;

--- a/tests/unit_tests/ast/reflect_02.cc
+++ b/tests/unit_tests/ast/reflect_02.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s
 // clang-format on
 
 struct S {

--- a/tests/unit_tests/ast/return_statement_01.cc
+++ b/tests/unit_tests/ast/return_statement_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 struct Pair {
   int first;

--- a/tests/unit_tests/ast/struct_alias_01.cc
+++ b/tests/unit_tests/ast/struct_alias_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 using Pair = struct {
   int a, b;

--- a/tests/unit_tests/ast/structured_binding_declaration_01.cc
+++ b/tests/unit_tests/ast/structured_binding_declaration_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 struct Pair {
   int first;

--- a/tests/unit_tests/ast/template_lambda_01.cc
+++ b/tests/unit_tests/ast/template_lambda_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 template <typename T>
 struct S {

--- a/tests/unit_tests/ast/template_member_expression_01.cc
+++ b/tests/unit_tests/ast/template_member_expression_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 struct Allocator {
   template <typename T>

--- a/tests/unit_tests/ast/template_nested_name_specifier_01.cc
+++ b/tests/unit_tests/ast/template_nested_name_specifier_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 struct HelperT {
   template <typename T>

--- a/tests/unit_tests/ast/template_type_parameter_01.cc
+++ b/tests/unit_tests/ast/template_type_parameter_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 template <typename T, template <typename U> class C>
 struct S {

--- a/tests/unit_tests/ast/uchar_array_index_01.c
+++ b/tests/unit_tests/ast/uchar_array_index_01.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s
 
 int main() {
   unsigned char c = 200;

--- a/tests/unit_tests/ast/underlying_type_specifier_01.cc
+++ b/tests/unit_tests/ast/underlying_type_specifier_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 enum class fruit { orange, apple };
 

--- a/tests/unit_tests/ast/using_enum_declaration_01.cc
+++ b/tests/unit_tests/ast/using_enum_declaration_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 enum class fruit { orange, apple };
 

--- a/tests/unit_tests/ast/variadic_function_01.cc
+++ b/tests/unit_tests/ast/variadic_function_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 void print_like(const char* fmt, ...);
 

--- a/tests/unit_tests/ast/variadic_function_02.cc
+++ b/tests/unit_tests/ast/variadic_function_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -verify -ast-dump %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -verify -ast-dump %s | %filecheck %s --match-full-lines
 
 void ff(int count, ...) {
   __builtin_va_list args;

--- a/tests/unit_tests/codegen/designated_array2d_sema_01.c
+++ b/tests/unit_tests/codegen/designated_array2d_sema_01.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 static int mat[3][4] = {

--- a/tests/unit_tests/parser/c_stdlib.c
+++ b/tests/unit_tests/parser/c_stdlib.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -toolchain wasm32 -verify -fcheck %s
+// RUN: %cxx -toolchain wasm32 -verify -fsyntax-only %s
 
 #include <assert.h>
 #include <complex.h>

--- a/tests/unit_tests/parser/indirect_goto.c
+++ b/tests/unit_tests/parser/indirect_goto.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // GCC extension: &&label gives the address of a label as void*
 // goto *expr jumps to the address stored in expr

--- a/tests/unit_tests/parser/indirect_goto.cc
+++ b/tests/unit_tests/parser/indirect_goto.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <bool Flag>
 int dispatch(void) {

--- a/tests/unit_tests/sema/address_op_01.cc
+++ b/tests/unit_tests/sema/address_op_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct X {
   int m{};

--- a/tests/unit_tests/sema/adl_01.cc
+++ b/tests/unit_tests/sema/adl_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 extern "C" int printf(const char*, ...);
 

--- a/tests/unit_tests/sema/adl_auto_param_01.cc
+++ b/tests/unit_tests/sema/adl_auto_param_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 auto add(auto x, auto y) -> decltype(x + y) { return x + y; }
 

--- a/tests/unit_tests/sema/adl_call_01.cc
+++ b/tests/unit_tests/sema/adl_call_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <typename T>
 T foo(T x) {

--- a/tests/unit_tests/sema/adl_free_operator_01.cc
+++ b/tests/unit_tests/sema/adl_free_operator_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <typename T>
 T foo(T x) {

--- a/tests/unit_tests/sema/adl_member_operator_01.cc
+++ b/tests/unit_tests/sema/adl_member_operator_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <typename T>
 T foo(T x) {

--- a/tests/unit_tests/sema/adl_template_arg_namespace_01.cc
+++ b/tests/unit_tests/sema/adl_template_arg_namespace_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 namespace lib {
 

--- a/tests/unit_tests/sema/aggregate_copy_init_01.c
+++ b/tests/unit_tests/sema/aggregate_copy_init_01.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct Point {

--- a/tests/unit_tests/sema/aligned_union_01.cc
+++ b/tests/unit_tests/sema/aligned_union_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 using size_t = decltype(sizeof(0));
 

--- a/tests/unit_tests/sema/aligned_union_02.cc
+++ b/tests/unit_tests/sema/aligned_union_02.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 using size_t = decltype(sizeof(0));
 

--- a/tests/unit_tests/sema/alignof_01.cc
+++ b/tests/unit_tests/sema/alignof_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -toolchain wasm32 -verify -fcheck %s
+// RUN: %cxx -toolchain wasm32 -verify -fsyntax-only %s
 
 static_assert(alignof(bool) == 1);
 static_assert(alignof(signed char) == 1);

--- a/tests/unit_tests/sema/anon_struct_layout_01.cc
+++ b/tests/unit_tests/sema/anon_struct_layout_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -toolchain macos -fcheck -dump-record-layouts %s | %filecheck %s
+// RUN: %cxx -toolchain macos -fsyntax-only -dump-record-layouts %s | %filecheck %s
 
 // Anonymous union with bitfields and regular fields interleaved with
 // anonymous structs. Verifies layout sizes, offsets, and nesting.

--- a/tests/unit_tests/sema/anon_struct_layout_02.cc
+++ b/tests/unit_tests/sema/anon_struct_layout_02.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -toolchain macos -fcheck -dump-record-layouts %s | %filecheck %s
+// RUN: %cxx -toolchain macos -fsyntax-only -dump-record-layouts %s | %filecheck %s
 
 // Anonymous union/struct with regular fields, verifying field ordering
 // and layout when anonymous members are interleaved with named fields.

--- a/tests/unit_tests/sema/assignment_void_pointer_c_01.c
+++ b/tests/unit_tests/sema/assignment_void_pointer_c_01.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 void* malloc(unsigned long);

--- a/tests/unit_tests/sema/assignment_void_pointer_cpp_01.cc
+++ b/tests/unit_tests/sema/assignment_void_pointer_cpp_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 void* malloc(unsigned long);
 

--- a/tests/unit_tests/sema/auto_template.cc
+++ b/tests/unit_tests/sema/auto_template.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -verify -fsyntax-only -dump-symbols %s | %filecheck %s
 
 extern "C" {
 int printf(const char* format, ...);

--- a/tests/unit_tests/sema/binary_invalid_bitwise_operands_01.cc
+++ b/tests/unit_tests/sema/binary_invalid_bitwise_operands_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct S {};
 

--- a/tests/unit_tests/sema/binary_invalid_logical_operands_01.cc
+++ b/tests/unit_tests/sema/binary_invalid_logical_operands_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct S {};
 

--- a/tests/unit_tests/sema/binder_duplicate_field_01.cc
+++ b/tests/unit_tests/sema/binder_duplicate_field_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct S {
   int value;

--- a/tests/unit_tests/sema/binder_invalid_template_id_01.cc
+++ b/tests/unit_tests/sema/binder_invalid_template_id_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <typename T>
 // expected-note@+1 {{candidate function not viable: template argument deduction failed}}

--- a/tests/unit_tests/sema/binder_nested_name_wrong_01.cc
+++ b/tests/unit_tests/sema/binder_nested_name_wrong_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 int NotAScope = 0;
 

--- a/tests/unit_tests/sema/binder_typealias_conflict_01.cc
+++ b/tests/unit_tests/sema/binder_typealias_conflict_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 typedef int Value;
 typedef float Value;  // expected-error {{conflicting declaration of 'Value'}}

--- a/tests/unit_tests/sema/binder_typealias_symbol_conflict_01.cc
+++ b/tests/unit_tests/sema/binder_typealias_symbol_conflict_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 int Value;
 typedef int Value;  // expected-error {{conflicting declaration of 'Value'}}

--- a/tests/unit_tests/sema/binder_unknown_base_class_01.cc
+++ b/tests/unit_tests/sema/binder_unknown_base_class_01.cc
@@ -1,3 +1,3 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct D : MissingBase {};  // expected-error {{unknown base class 'MissingBase'}}

--- a/tests/unit_tests/sema/binder_using_unresolved_01.cc
+++ b/tests/unit_tests/sema/binder_using_unresolved_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct Base {};
 

--- a/tests/unit_tests/sema/bitfield_init_c_01.c
+++ b/tests/unit_tests/sema/bitfield_init_c_01.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -fsyntax-only -verify -fcheck %s
+// RUN: %cxx -fsyntax-only -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 // Test non-designated struct init with bitfields.

--- a/tests/unit_tests/sema/bitfields_01.cc
+++ b/tests/unit_tests/sema/bitfields_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct S {
   int a : 3;

--- a/tests/unit_tests/sema/bitfields_layout_01.cc
+++ b/tests/unit_tests/sema/bitfields_layout_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-record-layouts %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -dump-record-layouts %s | %filecheck %s
 
 struct A {
   int a : 3;

--- a/tests/unit_tests/sema/bitfields_layout_02.cc
+++ b/tests/unit_tests/sema/bitfields_layout_02.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -toolchain macos -fcheck -dump-record-layouts %s | %filecheck %s
+// RUN: %cxx -toolchain macos -fsyntax-only -dump-record-layouts %s | %filecheck %s
 
 // Cross-type packing (Itanium ABI: all fit contiguously)
 struct X {

--- a/tests/unit_tests/sema/bitfields_layout_03.cc
+++ b/tests/unit_tests/sema/bitfields_layout_03.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -toolchain macos -fcheck -dump-record-layouts %s | %filecheck %s
+// RUN: %cxx -toolchain macos -fsyntax-only -dump-record-layouts %s | %filecheck %s
 
 // Bitfield then regular field then bitfield (Itanium ABI packing)
 struct T1 { int a : 2; char b; int c : 3; };

--- a/tests/unit_tests/sema/bitint_01.cc
+++ b/tests/unit_tests/sema/bitint_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -toolchain macos -verify -fcheck %s
+// RUN: %cxx -toolchain macos -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 constexpr unsigned N = 128;

--- a/tests/unit_tests/sema/bitint_02.cc
+++ b/tests/unit_tests/sema/bitint_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -toolchain macos -verify -fcheck %s
+// RUN: %cxx -toolchain macos -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 int main() {

--- a/tests/unit_tests/sema/bitint_negative_size_01.cc
+++ b/tests/unit_tests/sema/bitint_negative_size_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -toolchain macos -verify -fcheck %s
+// RUN: %cxx -toolchain macos -verify -fsyntax-only %s
 
 _BitInt(-1) a;          // expected-error {{signed _BitInt of bit sizes greater than 128 not supported}}
 unsigned _BitInt(-1) b; // expected-error {{unsigned _BitInt of bit sizes greater than 128 not supported}}

--- a/tests/unit_tests/sema/bitint_sizeof_01.cc
+++ b/tests/unit_tests/sema/bitint_sizeof_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -toolchain macos -verify -fcheck %s
+// RUN: %cxx -toolchain macos -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 static_assert(sizeof(_BitInt(8)) == 1);

--- a/tests/unit_tests/sema/bitint_template_param_01.cc
+++ b/tests/unit_tests/sema/bitint_template_param_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck %s
+// RUN: %cxx -fsyntax-only %s
 // expected-no-diagnostics
 
 template <int i>

--- a/tests/unit_tests/sema/bitint_too_large_01.cc
+++ b/tests/unit_tests/sema/bitint_too_large_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -toolchain macos -verify -fcheck %s
+// RUN: %cxx -toolchain macos -verify -fsyntax-only %s
 
 unsigned _BitInt(129) a; // expected-error {{unsigned _BitInt of bit sizes greater than 128 not supported}}
 unsigned _BitInt(256) b; // expected-error {{unsigned _BitInt of bit sizes greater than 128 not supported}}

--- a/tests/unit_tests/sema/bitint_too_small_01.cc
+++ b/tests/unit_tests/sema/bitint_too_small_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -toolchain macos -verify -fcheck %s
+// RUN: %cxx -toolchain macos -verify -fsyntax-only %s
 
 _BitInt(0) a;          // expected-error {{signed _BitInt must have a bit size of at least 2}}
 _BitInt(1) b;          // expected-error {{signed _BitInt must have a bit size of at least 2}}

--- a/tests/unit_tests/sema/bitint_wb_literals_01.cc
+++ b/tests/unit_tests/sema/bitint_wb_literals_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -toolchain macos -verify -fcheck %s
+// RUN: %cxx -toolchain macos -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 static_assert(__is_same(decltype(3wb),    _BitInt(3)));

--- a/tests/unit_tests/sema/bitint_wb_literals_02.cc
+++ b/tests/unit_tests/sema/bitint_wb_literals_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -toolchain macos -verify -fcheck %s
+// RUN: %cxx -toolchain macos -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 static_assert(sizeof(3wb)    == 1);

--- a/tests/unit_tests/sema/bitwise_not_01.cc
+++ b/tests/unit_tests/sema/bitwise_not_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 auto main() -> int {
   static_assert(__is_same(decltype(~'a'), int));

--- a/tests/unit_tests/sema/brace_elision_c_01.c
+++ b/tests/unit_tests/sema/brace_elision_c_01.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct point {

--- a/tests/unit_tests/sema/builtin_alloca_01.cc
+++ b/tests/unit_tests/sema/builtin_alloca_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 void test(int n) {
   void* p = __builtin_alloca(n);

--- a/tests/unit_tests/sema/builtin_bit_cast_diag_01.cc
+++ b/tests/unit_tests/sema/builtin_bit_cast_diag_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // expected-error@1 {{__builtin_bit_cast requires source and destination to have the same size}}
 auto bad = __builtin_bit_cast(double, 1);

--- a/tests/unit_tests/sema/builtin_bit_cast_ok_01.cc
+++ b/tests/unit_tests/sema/builtin_bit_cast_ok_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 auto ok = __builtin_bit_cast(float, 1);

--- a/tests/unit_tests/sema/builtin_constant_p_01.cc
+++ b/tests/unit_tests/sema/builtin_constant_p_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 static_assert(__builtin_constant_p(42));

--- a/tests/unit_tests/sema/builtin_functions_01.cc
+++ b/tests/unit_tests/sema/builtin_functions_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // expected-no-diagnostics
 

--- a/tests/unit_tests/sema/builtin_huge_val_01.cc
+++ b/tests/unit_tests/sema/builtin_huge_val_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 static_assert(__builtin_huge_val() > 1e308);
 static_assert(__builtin_huge_valf() > 1e38f);

--- a/tests/unit_tests/sema/builtin_missing_diag_01.cc
+++ b/tests/unit_tests/sema/builtin_missing_diag_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // expected-error@1 {{unknown builtin function '__builtin_shufflevector'}}
 int x = __builtin_shufflevector();

--- a/tests/unit_tests/sema/builtin_nans_01.cc
+++ b/tests/unit_tests/sema/builtin_nans_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 void test() {
   double d = __builtin_nans("");

--- a/tests/unit_tests/sema/builtin_operator_new_01.cc
+++ b/tests/unit_tests/sema/builtin_operator_new_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 void test() {
   void* p = __builtin_operator_new(16);

--- a/tests/unit_tests/sema/builtin_source_location_01.cc
+++ b/tests/unit_tests/sema/builtin_source_location_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 static_assert(__builtin_LINE() > 0);
 

--- a/tests/unit_tests/sema/builtins_01.cc
+++ b/tests/unit_tests/sema/builtins_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // Test builtin math functions
 void test_math_builtins() {

--- a/tests/unit_tests/sema/builtins_constexpr_01.cc
+++ b/tests/unit_tests/sema/builtins_constexpr_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 static_assert(__builtin_abs(-42) == 42);

--- a/tests/unit_tests/sema/byte_bitwise_wasm_01.cc
+++ b/tests/unit_tests/sema/byte_bitwise_wasm_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck -toolchain wasm32 %s
+// RUN: %cxx -verify -fsyntax-only -toolchain wasm32 %s
 // expected-no-diagnostics
 
 #include <cstddef>

--- a/tests/unit_tests/sema/c_style_cast_01.cc
+++ b/tests/unit_tests/sema/c_style_cast_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct B {
   int x;

--- a/tests/unit_tests/sema/call_c_01.c
+++ b/tests/unit_tests/sema/call_c_01.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 int f() { return 0; }
 

--- a/tests/unit_tests/sema/call_template_nontemplate_prefer_01.cc
+++ b/tests/unit_tests/sema/call_template_nontemplate_prefer_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct NonTemplateTag {};

--- a/tests/unit_tests/sema/call_user_conversion_template_overload_01.cc
+++ b/tests/unit_tests/sema/call_user_conversion_template_overload_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct Source {

--- a/tests/unit_tests/sema/cast_errors_01.cc
+++ b/tests/unit_tests/sema/cast_errors_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct B {
   int x;

--- a/tests/unit_tests/sema/class_01.cc
+++ b/tests/unit_tests/sema/class_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct X {
   void f() {

--- a/tests/unit_tests/sema/class_02.cc
+++ b/tests/unit_tests/sema/class_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct A {
   struct {

--- a/tests/unit_tests/sema/class_body_recovery_01.cc
+++ b/tests/unit_tests/sema/class_body_recovery_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // Tests that class body recovery skips to the next semicolon
 // and doesn't cascade hundreds of "expected a declaration" errors.
 

--- a/tests/unit_tests/sema/common_type_no_recursion_01.cc
+++ b/tests/unit_tests/sema/common_type_no_recursion_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class _Tp, _Tp __v>

--- a/tests/unit_tests/sema/condition_decl_invalid_condition_01.cc
+++ b/tests/unit_tests/sema/condition_decl_invalid_condition_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct S {};
 

--- a/tests/unit_tests/sema/conditional_expr_01.cc
+++ b/tests/unit_tests/sema/conditional_expr_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct Base {};
 struct Derived : Base {};

--- a/tests/unit_tests/sema/conditional_invalid_condition_01.cc
+++ b/tests/unit_tests/sema/conditional_invalid_condition_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct S {};
 

--- a/tests/unit_tests/sema/conditional_ptr_conversion_c_01.c
+++ b/tests/unit_tests/sema/conditional_ptr_conversion_c_01.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct Elem {
   struct Elem *next;

--- a/tests/unit_tests/sema/conditional_unresolved_operand_01.cc
+++ b/tests/unit_tests/sema/conditional_unresolved_operand_01.cc
@@ -1,3 +1,3 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 int x = true ? missing_value : 1; // expected-error {{use of undeclared identifier 'missing_value'}}

--- a/tests/unit_tests/sema/const_cast_01.cc
+++ b/tests/unit_tests/sema/const_cast_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -toolchain macos -verify -fcheck %s
+// RUN: %cxx -toolchain macos -verify -fsyntax-only %s
 
 void test_const_cast() {
   int i = 0;

--- a/tests/unit_tests/sema/const_overload_01.cc
+++ b/tests/unit_tests/sema/const_overload_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct K {
   auto begin() const -> int { return 0; }

--- a/tests/unit_tests/sema/constant_expression_01.cc
+++ b/tests/unit_tests/sema/constant_expression_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 static_assert('0');
 static_assert(('0'));

--- a/tests/unit_tests/sema/constexpr_call_01.cc
+++ b/tests/unit_tests/sema/constexpr_call_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 constexpr int add(int a, int b) { return a + b; }
 

--- a/tests/unit_tests/sema/constexpr_class_01.cc
+++ b/tests/unit_tests/sema/constexpr_class_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct Point {
   int x;

--- a/tests/unit_tests/sema/constexpr_defaulted_ctor_01.cc
+++ b/tests/unit_tests/sema/constexpr_defaulted_ctor_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct allocator_arg_t {

--- a/tests/unit_tests/sema/constexpr_member_01.cc
+++ b/tests/unit_tests/sema/constexpr_member_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct Pair {
   int first;

--- a/tests/unit_tests/sema/constexpr_nttp_01.cc
+++ b/tests/unit_tests/sema/constexpr_nttp_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <int N>
 constexpr int identity() {

--- a/tests/unit_tests/sema/constructor_default_args_01.cc
+++ b/tests/unit_tests/sema/constructor_default_args_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct A {

--- a/tests/unit_tests/sema/conversion_op_template_01.cc
+++ b/tests/unit_tests/sema/conversion_op_template_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct Any {

--- a/tests/unit_tests/sema/conversion_sequence_01.cc
+++ b/tests/unit_tests/sema/conversion_sequence_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct Wrapper {
   Wrapper(int x) {}

--- a/tests/unit_tests/sema/copy_move_ctor_01.cc
+++ b/tests/unit_tests/sema/copy_move_ctor_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct Simple {
   int x;

--- a/tests/unit_tests/sema/ctor_01.cc
+++ b/tests/unit_tests/sema/ctor_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct C {
   struct bar {};

--- a/tests/unit_tests/sema/ctor_02.cc
+++ b/tests/unit_tests/sema/ctor_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-symbols %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -dump-symbols %s | %filecheck %s --match-full-lines
 
 struct X {
   int i;

--- a/tests/unit_tests/sema/decltype_01.cc
+++ b/tests/unit_tests/sema/decltype_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 static_assert(__is_null_pointer(decltype(nullptr)));
 

--- a/tests/unit_tests/sema/decltype_dependent_alias_01.cc
+++ b/tests/unit_tests/sema/decltype_dependent_alias_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 namespace std {
 inline namespace __1 {

--- a/tests/unit_tests/sema/deduction_guide_symbol_01.cc
+++ b/tests/unit_tests/sema/deduction_guide_symbol_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -verify -fsyntax-only -dump-symbols %s | %filecheck %s
 
 template <typename T>
 struct List {

--- a/tests/unit_tests/sema/deduction_guide_symbol_02.cc
+++ b/tests/unit_tests/sema/deduction_guide_symbol_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -verify -fsyntax-only -dump-symbols %s | %filecheck %s
 
 struct Outer {
   template <typename T>

--- a/tests/unit_tests/sema/default_arguments_redecl_01.cc
+++ b/tests/unit_tests/sema/default_arguments_redecl_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 void f(int x = 1);
 

--- a/tests/unit_tests/sema/deferred_member_template_01.cc
+++ b/tests/unit_tests/sema/deferred_member_template_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 typedef decltype(sizeof(int)) size_t;

--- a/tests/unit_tests/sema/dependent_named_type_specifier_01.cc
+++ b/tests/unit_tests/sema/dependent_named_type_specifier_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class _Tp, _Tp __v>

--- a/tests/unit_tests/sema/dependent_ref_init_01.cc
+++ b/tests/unit_tests/sema/dependent_ref_init_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class T>

--- a/tests/unit_tests/sema/empty_pack_01.cc
+++ b/tests/unit_tests/sema/empty_pack_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <typename... Ts>
 constexpr int count(Ts... args) {

--- a/tests/unit_tests/sema/enum_c_01.c
+++ b/tests/unit_tests/sema/enum_c_01.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck -dump-symbols -xc %s | %filecheck %s
+// RUN: %cxx -verify -fsyntax-only -dump-symbols -xc %s | %filecheck %s
 
 enum X {
   A,

--- a/tests/unit_tests/sema/enum_underlying_01.cc
+++ b/tests/unit_tests/sema/enum_underlying_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 enum Plain { a = 0, b = 1, c = 5 };
 enum PlainNeg { x = -1, y = 0 };

--- a/tests/unit_tests/sema/explicit_spec_after_implicit_01.cc
+++ b/tests/unit_tests/sema/explicit_spec_after_implicit_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class _Tp = void>

--- a/tests/unit_tests/sema/extern_c_linkage_01.cc
+++ b/tests/unit_tests/sema/extern_c_linkage_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -verify -fsyntax-only -dump-symbols %s | %filecheck %s
 
 // Brace form: extern "C" { ... }
 extern "C" {

--- a/tests/unit_tests/sema/extern_in_block_func_01.c
+++ b/tests/unit_tests/sema/extern_in_block_func_01.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 void caller() {

--- a/tests/unit_tests/sema/extern_in_block_var_01.c
+++ b/tests/unit_tests/sema/extern_in_block_var_01.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 void writer() {

--- a/tests/unit_tests/sema/extern_in_block_var_02.c
+++ b/tests/unit_tests/sema/extern_in_block_var_02.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 void use_code() {

--- a/tests/unit_tests/sema/ferror_limit_01.cc
+++ b/tests/unit_tests/sema/ferror_limit_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck -ferror-limit 2 %s
+// RUN: %cxx -verify -fsyntax-only -ferror-limit 2 %s
 
 template <int>
 struct S;

--- a/tests/unit_tests/sema/for_range_01.cc
+++ b/tests/unit_tests/sema/for_range_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 int sum_array() {
   int arr[4] = {1, 2, 3, 4};

--- a/tests/unit_tests/sema/friend_decl_01.cc
+++ b/tests/unit_tests/sema/friend_decl_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct X {
   friend void found_by_adl(X) {}  // hidden friend, defined inline

--- a/tests/unit_tests/sema/friend_decl_02.cc
+++ b/tests/unit_tests/sema/friend_decl_02.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct X {
   friend void foo(X*);

--- a/tests/unit_tests/sema/friend_decl_03.cc
+++ b/tests/unit_tests/sema/friend_decl_03.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 class K;
 

--- a/tests/unit_tests/sema/function_params_01.cc
+++ b/tests/unit_tests/sema/function_params_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -verify -fsyntax-only -dump-symbols %s | %filecheck %s
 // clang-format on
 
 struct C {

--- a/tests/unit_tests/sema/function_redecl_array_default_arg_01.cc
+++ b/tests/unit_tests/sema/function_redecl_array_default_arg_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 void g(int a[4] = nullptr);
 

--- a/tests/unit_tests/sema/function_redecl_array_param_01.cc
+++ b/tests/unit_tests/sema/function_redecl_array_param_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 void f(int a[4]);

--- a/tests/unit_tests/sema/fwd_class_01.cc
+++ b/tests/unit_tests/sema/fwd_class_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -verify -fsyntax-only -dump-symbols %s | %filecheck %s
 
 namespace cxx {
 class BasicBlock;

--- a/tests/unit_tests/sema/generic_selection_01.cc
+++ b/tests/unit_tests/sema/generic_selection_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // clang-format off
 

--- a/tests/unit_tests/sema/if_condition_decl_01.cc
+++ b/tests/unit_tests/sema/if_condition_decl_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct Base {

--- a/tests/unit_tests/sema/implicit_member_call_01.cc
+++ b/tests/unit_tests/sema/implicit_member_call_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct Counter {

--- a/tests/unit_tests/sema/implicit_special_members_01.cc
+++ b/tests/unit_tests/sema/implicit_special_members_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-symbols %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -dump-symbols %s | %filecheck %s --match-full-lines
 
 struct Pod {
   int x;

--- a/tests/unit_tests/sema/incr_01.cc
+++ b/tests/unit_tests/sema/incr_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 auto main() -> int {
   char c{};

--- a/tests/unit_tests/sema/incr_c_01.c
+++ b/tests/unit_tests/sema/incr_c_01.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck -xc %s
+// RUN: %cxx -verify -fsyntax-only -xc %s
 
 enum E { a, b, c };
 

--- a/tests/unit_tests/sema/indirect_goto_c_01.c
+++ b/tests/unit_tests/sema/indirect_goto_c_01.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 int main() {
   void* target = 0;

--- a/tests/unit_tests/sema/init_anon_union_struct_01.c
+++ b/tests/unit_tests/sema/init_anon_union_struct_01.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct S1 {

--- a/tests/unit_tests/sema/init_char_array_from_ints_01.c
+++ b/tests/unit_tests/sema/init_char_array_from_ints_01.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 #define tkgt 1
 #define tkappend 2

--- a/tests/unit_tests/sema/init_class_construction_01.cc
+++ b/tests/unit_tests/sema/init_class_construction_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct Point {
   int x;

--- a/tests/unit_tests/sema/init_designated_01.cc
+++ b/tests/unit_tests/sema/init_designated_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct Point {
   int x;

--- a/tests/unit_tests/sema/init_errors_01.cc
+++ b/tests/unit_tests/sema/init_errors_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // clang-format off
 

--- a/tests/unit_tests/sema/init_member_char_array_string_01.cc
+++ b/tests/unit_tests/sema/init_member_char_array_string_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct Token {
   int id;

--- a/tests/unit_tests/sema/init_narrowing_01.cc
+++ b/tests/unit_tests/sema/init_narrowing_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // clang-format off
 

--- a/tests/unit_tests/sema/init_narrowing_no_warning_01.cc
+++ b/tests/unit_tests/sema/init_narrowing_no_warning_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct S {

--- a/tests/unit_tests/sema/init_paren_01.cc
+++ b/tests/unit_tests/sema/init_paren_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 void test_paren_initialization() {

--- a/tests/unit_tests/sema/init_reference_binding_01.cc
+++ b/tests/unit_tests/sema/init_reference_binding_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 int main() {
   // expected-error@+1 {{invalid initialization of reference of type 'int&' from expression of type 'int'}}

--- a/tests/unit_tests/sema/init_reference_valid_01.cc
+++ b/tests/unit_tests/sema/init_reference_valid_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 int main() {

--- a/tests/unit_tests/sema/init_struct_01.cc
+++ b/tests/unit_tests/sema/init_struct_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct Point {
   int x;

--- a/tests/unit_tests/sema/initializer_list_01.cc
+++ b/tests/unit_tests/sema/initializer_list_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 #include <initializer_list>

--- a/tests/unit_tests/sema/injected_class_name_01.cc
+++ b/tests/unit_tests/sema/injected_class_name_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -dump-symbols %s | %filecheck %s
 
 struct Foo {
   Foo* self() { return this; }

--- a/tests/unit_tests/sema/int128_arith_01.cc
+++ b/tests/unit_tests/sema/int128_arith_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -toolchain macos -verify -fcheck %s
+// RUN: %cxx -toolchain macos -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 int main() {

--- a/tests/unit_tests/sema/is_base_of_01.cc
+++ b/tests/unit_tests/sema/is_base_of_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct Base;
 struct OtherBase;

--- a/tests/unit_tests/sema/is_constructible_01.cc
+++ b/tests/unit_tests/sema/is_constructible_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <class T, T v>
 struct integral_constant {

--- a/tests/unit_tests/sema/is_convertible_01.cc
+++ b/tests/unit_tests/sema/is_convertible_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // expected-no-diagnostics
 

--- a/tests/unit_tests/sema/is_final_01.cc
+++ b/tests/unit_tests/sema/is_final_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct C {};
 

--- a/tests/unit_tests/sema/lazy_instantiation_01.cc
+++ b/tests/unit_tests/sema/lazy_instantiation_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -dump-symbols %s | %filecheck %s
 
 template <typename T>
 struct S {

--- a/tests/unit_tests/sema/lazy_instantiation_02.cc
+++ b/tests/unit_tests/sema/lazy_instantiation_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -dump-symbols %s | %filecheck %s
 
 template <typename T>
 struct S {

--- a/tests/unit_tests/sema/lazy_instantiation_03.cc
+++ b/tests/unit_tests/sema/lazy_instantiation_03.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -dump-symbols %s | %filecheck %s
 
 template <typename T>
 struct S {

--- a/tests/unit_tests/sema/lazy_instantiation_04.cc
+++ b/tests/unit_tests/sema/lazy_instantiation_04.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -dump-symbols %s | %filecheck %s
 
 template <typename T>
 struct Base {

--- a/tests/unit_tests/sema/lazy_instantiation_05.cc
+++ b/tests/unit_tests/sema/lazy_instantiation_05.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -dump-symbols %s | %filecheck %s
 
 template <typename T>
 struct S {

--- a/tests/unit_tests/sema/lazy_instantiation_06.cc
+++ b/tests/unit_tests/sema/lazy_instantiation_06.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -dump-symbols %s | %filecheck %s
 
 template <typename T>
 struct S {

--- a/tests/unit_tests/sema/lazy_instantiation_07.cc
+++ b/tests/unit_tests/sema/lazy_instantiation_07.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -dump-symbols %s | %filecheck %s
 
 template <typename T>
 struct S {

--- a/tests/unit_tests/sema/logical_neg_01.cc
+++ b/tests/unit_tests/sema/logical_neg_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 auto main() -> int {
   static_assert(__is_same(decltype(!true), bool));

--- a/tests/unit_tests/sema/lookup_anonymous_member_01.cc
+++ b/tests/unit_tests/sema/lookup_anonymous_member_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // Anonymous struct/union member lookup: members of anonymous
 // structs/unions should be found as if they were direct members.

--- a/tests/unit_tests/sema/lookup_base_class_01.cc
+++ b/tests/unit_tests/sema/lookup_base_class_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // Base class member lookup: names inherited from base classes
 // should be found by unqualified lookup in derived classes.

--- a/tests/unit_tests/sema/lookup_qualified_01.cc
+++ b/tests/unit_tests/sema/lookup_qualified_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // Qualified lookup through nested name specifiers with multiple levels.
 

--- a/tests/unit_tests/sema/lookup_type_alias_01.cc
+++ b/tests/unit_tests/sema/lookup_type_alias_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // Type alias qualified lookup: looking up types through
 // type aliases and using declarations used as scope qualifiers.

--- a/tests/unit_tests/sema/lookup_using_directive_01.cc
+++ b/tests/unit_tests/sema/lookup_using_directive_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // Using-directive lookup: names made visible by using-directives
 // should be found by unqualified lookup.

--- a/tests/unit_tests/sema/make_integer_seq_01.cc
+++ b/tests/unit_tests/sema/make_integer_seq_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // expected-no-diagnostics
 

--- a/tests/unit_tests/sema/mem_init.cc
+++ b/tests/unit_tests/sema/mem_init.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 extern "C" {
 int printf(const char* format, ...);

--- a/tests/unit_tests/sema/member_access_01.cc
+++ b/tests/unit_tests/sema/member_access_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // clang-format off
 

--- a/tests/unit_tests/sema/member_access_02.cc
+++ b/tests/unit_tests/sema/member_access_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck -freport-missing-types %s
+// RUN: %cxx -verify -fsyntax-only -freport-missing-types %s
 
 struct X {
   enum E { kValue = 0 };

--- a/tests/unit_tests/sema/member_access_03.cc
+++ b/tests/unit_tests/sema/member_access_03.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck -freport-missing-types %s
+// RUN: %cxx -verify -fsyntax-only -freport-missing-types %s
 
 struct X {
   int a[1];

--- a/tests/unit_tests/sema/member_access_missing_01.cc
+++ b/tests/unit_tests/sema/member_access_missing_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct S {};
 

--- a/tests/unit_tests/sema/member_access_on_non_class_in_template.cc
+++ b/tests/unit_tests/sema/member_access_on_non_class_in_template.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <typename T>
 void g(T t) {

--- a/tests/unit_tests/sema/memory_ratio_dependent_01.cc
+++ b/tests/unit_tests/sema/memory_ratio_dependent_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <long N, long D>
 struct ratio {

--- a/tests/unit_tests/sema/memory_ratio_nns_substitution_01.cc
+++ b/tests/unit_tests/sema/memory_ratio_nns_substitution_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <long _Num, long _Den = 1>
 struct ratio {

--- a/tests/unit_tests/sema/nested_class_member_access_01.cc
+++ b/tests/unit_tests/sema/nested_class_member_access_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -c %s 2>&1 | %filecheck %s --allow-empty
+// RUN: %cxx -fsyntax-only -c %s 2>&1 | %filecheck %s --allow-empty
 // CHECK-NOT: error
 
 struct ConstValue {

--- a/tests/unit_tests/sema/noexcept_expr_01.cc
+++ b/tests/unit_tests/sema/noexcept_expr_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // Literals and arithmetic - never throw
 static_assert(noexcept(1 + 2));

--- a/tests/unit_tests/sema/noexcept_expr_02.cc
+++ b/tests/unit_tests/sema/noexcept_expr_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // Variable template using noexcept as constexpr bool
 template <typename T>

--- a/tests/unit_tests/sema/noexcept_expr_03.cc
+++ b/tests/unit_tests/sema/noexcept_expr_03.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct WithUnary {
   WithUnary operator-() noexcept;

--- a/tests/unit_tests/sema/noexcept_expr_04.cc
+++ b/tests/unit_tests/sema/noexcept_expr_04.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct S {
   S& operator+=(const S&) noexcept;

--- a/tests/unit_tests/sema/noexcept_specifier_expr_01.cc
+++ b/tests/unit_tests/sema/noexcept_specifier_expr_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 void f1() noexcept(true);
 static_assert(noexcept(f1()));

--- a/tests/unit_tests/sema/null_pointer_constant_01.cc
+++ b/tests/unit_tests/sema/null_pointer_constant_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 extern "C" void abort();
 

--- a/tests/unit_tests/sema/operator_overload_ambiguous_01.cc
+++ b/tests/unit_tests/sema/operator_overload_ambiguous_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct A {};
 

--- a/tests/unit_tests/sema/operator_overload_arrow_01.cc
+++ b/tests/unit_tests/sema/operator_overload_arrow_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct Ptr {

--- a/tests/unit_tests/sema/operator_overload_assignment_01.cc
+++ b/tests/unit_tests/sema/operator_overload_assignment_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct Box {

--- a/tests/unit_tests/sema/operator_overload_binary_01.cc
+++ b/tests/unit_tests/sema/operator_overload_binary_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct Vec {

--- a/tests/unit_tests/sema/operator_overload_call_01.cc
+++ b/tests/unit_tests/sema/operator_overload_call_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct Adder {

--- a/tests/unit_tests/sema/operator_overload_call_02.cc
+++ b/tests/unit_tests/sema/operator_overload_call_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct G {

--- a/tests/unit_tests/sema/operator_overload_call_blocker_01.cc
+++ b/tests/unit_tests/sema/operator_overload_call_blocker_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct F {

--- a/tests/unit_tests/sema/operator_overload_compound_assignment_01.cc
+++ b/tests/unit_tests/sema/operator_overload_compound_assignment_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct Sum {

--- a/tests/unit_tests/sema/operator_overload_conversion_rank_01.cc
+++ b/tests/unit_tests/sema/operator_overload_conversion_rank_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct A {};

--- a/tests/unit_tests/sema/operator_overload_nullptr_ambiguous_01.cc
+++ b/tests/unit_tests/sema/operator_overload_nullptr_ambiguous_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct P {};
 

--- a/tests/unit_tests/sema/operator_overload_postfix_01.cc
+++ b/tests/unit_tests/sema/operator_overload_postfix_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct Counter {

--- a/tests/unit_tests/sema/operator_overload_shift_01.cc
+++ b/tests/unit_tests/sema/operator_overload_shift_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct Stream {};

--- a/tests/unit_tests/sema/operator_overload_subscript_01.cc
+++ b/tests/unit_tests/sema/operator_overload_subscript_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct Buffer {

--- a/tests/unit_tests/sema/operator_overload_unary_01.cc
+++ b/tests/unit_tests/sema/operator_overload_unary_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct Num {

--- a/tests/unit_tests/sema/overload_ellipsis_01.cc
+++ b/tests/unit_tests/sema/overload_ellipsis_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 int f_exact(int x) { return x; }

--- a/tests/unit_tests/sema/overload_qual_rank_01.cc
+++ b/tests/unit_tests/sema/overload_qual_rank_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 namespace prefer_exact_over_qual {

--- a/tests/unit_tests/sema/overload_resolution_01.cc
+++ b/tests/unit_tests/sema/overload_resolution_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 namespace overload_resolution_basic {

--- a/tests/unit_tests/sema/pack_index_01.cc
+++ b/tests/unit_tests/sema/pack_index_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -dump-symbols %s | %filecheck %s
 // expected-no-diagnostics
 
 template <int i>

--- a/tests/unit_tests/sema/pragma_pack_01.c
+++ b/tests/unit_tests/sema/pragma_pack_01.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -toolchain macos -fcheck %s
+// RUN: %cxx -toolchain macos -fsyntax-only %s
 
 #pragma pack(push, 1)
 

--- a/tests/unit_tests/sema/ref_binding_cv_overload_01.cc
+++ b/tests/unit_tests/sema/ref_binding_cv_overload_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct L {};

--- a/tests/unit_tests/sema/ref_binding_forwarding_01.cc
+++ b/tests/unit_tests/sema/ref_binding_forwarding_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct L {};

--- a/tests/unit_tests/sema/ref_binding_nonconst_reject_01.cc
+++ b/tests/unit_tests/sema/ref_binding_nonconst_reject_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // expected-note@+1 {{candidate function not viable: no known conversion from 'short' to 'int&' for argument 1}}
 void accept(int&);

--- a/tests/unit_tests/sema/reflect_01.cc
+++ b/tests/unit_tests/sema/reflect_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 namespace std {
 namespace meta {

--- a/tests/unit_tests/sema/reflect_unresolved_operand_01.cc
+++ b/tests/unit_tests/sema/reflect_unresolved_operand_01.cc
@@ -1,3 +1,3 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 auto r = ^^missing_symbol; // expected-error {{use of undeclared identifier 'missing_symbol'}}

--- a/tests/unit_tests/sema/reinterpret_cast_01.cc
+++ b/tests/unit_tests/sema/reinterpret_cast_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct A {
   int x;

--- a/tests/unit_tests/sema/requires_clause_overload_01.cc
+++ b/tests/unit_tests/sema/requires_clause_overload_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <bool x>

--- a/tests/unit_tests/sema/sizeof_01.cc
+++ b/tests/unit_tests/sema/sizeof_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -toolchain wasm32 -verify -fcheck %s
+// RUN: %cxx -toolchain wasm32 -verify -fsyntax-only %s
 
 static_assert(sizeof(bool) == 1);
 static_assert(sizeof(signed char) == 1);

--- a/tests/unit_tests/sema/sizeof_array_deref_01.c
+++ b/tests/unit_tests/sema/sizeof_array_deref_01.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 typedef int elem_t;
 elem_t arr[10];

--- a/tests/unit_tests/sema/splice_invalid_expression_01.cc
+++ b/tests/unit_tests/sema/splice_invalid_expression_01.cc
@@ -1,3 +1,3 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 auto v = [:missing_value:]; // expected-error {{use of undeclared identifier 'missing_value'}}

--- a/tests/unit_tests/sema/standard_conversion_01.cc
+++ b/tests/unit_tests/sema/standard_conversion_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // clang-format off
 

--- a/tests/unit_tests/sema/standard_conversion_arith_01.cc
+++ b/tests/unit_tests/sema/standard_conversion_arith_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // clang-format off
 

--- a/tests/unit_tests/sema/standard_conversion_bool_01.cc
+++ b/tests/unit_tests/sema/standard_conversion_bool_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // clang-format off
 

--- a/tests/unit_tests/sema/standard_conversion_fctptr_01.cc
+++ b/tests/unit_tests/sema/standard_conversion_fctptr_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // clang-format off
 

--- a/tests/unit_tests/sema/standard_conversion_fpint_01.cc
+++ b/tests/unit_tests/sema/standard_conversion_fpint_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // clang-format off
 

--- a/tests/unit_tests/sema/standard_conversion_integral_01.cc
+++ b/tests/unit_tests/sema/standard_conversion_integral_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // clang-format off
 

--- a/tests/unit_tests/sema/standard_conversion_mem_01.cc
+++ b/tests/unit_tests/sema/standard_conversion_mem_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // clang-format off
 

--- a/tests/unit_tests/sema/standard_conversion_prom_01.cc
+++ b/tests/unit_tests/sema/standard_conversion_prom_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // clang-format off
 

--- a/tests/unit_tests/sema/standard_conversion_ptr_01.cc
+++ b/tests/unit_tests/sema/standard_conversion_ptr_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // clang-format off
 

--- a/tests/unit_tests/sema/standard_conversion_qual_01.cc
+++ b/tests/unit_tests/sema/standard_conversion_qual_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // clang-format off
 

--- a/tests/unit_tests/sema/static_assert_01.cc
+++ b/tests/unit_tests/sema/static_assert_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 static_assert(true);
 static_assert('a');

--- a/tests/unit_tests/sema/static_cast_01.cc
+++ b/tests/unit_tests/sema/static_cast_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct X {};
 

--- a/tests/unit_tests/sema/static_cast_02.cc
+++ b/tests/unit_tests/sema/static_cast_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck -freport-missing-types  %s
+// RUN: %cxx -verify -fsyntax-only -freport-missing-types  %s
 
 // clang-format off
 

--- a/tests/unit_tests/sema/static_cast_03.cc
+++ b/tests/unit_tests/sema/static_cast_03.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct B {
   int x;

--- a/tests/unit_tests/sema/string_literals_01.cc
+++ b/tests/unit_tests/sema/string_literals_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 static_assert(__is_same(decltype("hello"), const char (&)[6]));
 static_assert(__is_same(decltype(""), const char (&)[1]));

--- a/tests/unit_tests/sema/string_literals_02.cc
+++ b/tests/unit_tests/sema/string_literals_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 static_assert(sizeof("\n") == 2);
 static_assert(sizeof("\t") == 2);

--- a/tests/unit_tests/sema/struct_c_01.c
+++ b/tests/unit_tests/sema/struct_c_01.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-symbols -xc %s | %filecheck %s --match-full-lines
+// RUN: %cxx -fsyntax-only -dump-symbols -xc %s | %filecheck %s --match-full-lines
 
 enum E {
   v,

--- a/tests/unit_tests/sema/substitution_pack_with_defaults_01.cc
+++ b/tests/unit_tests/sema/substitution_pack_with_defaults_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 // Class template with all-defaulted parameters.

--- a/tests/unit_tests/sema/substitution_trailing_after_pack_01.cc
+++ b/tests/unit_tests/sema/substitution_trailing_after_pack_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 // Variadic function template with deduced trailing parameter.

--- a/tests/unit_tests/sema/subtraction_01.cc
+++ b/tests/unit_tests/sema/subtraction_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 auto main() -> int {
   char* p;

--- a/tests/unit_tests/sema/switch_condition_decl_01.cc
+++ b/tests/unit_tests/sema/switch_condition_decl_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 int compute() { return 2; }

--- a/tests/unit_tests/sema/template_alias_01.cc
+++ b/tests/unit_tests/sema/template_alias_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -dump-symbols %s | %filecheck %s
 
 template <typename T>
 using Pointer = T*;

--- a/tests/unit_tests/sema/template_alias_02.cc
+++ b/tests/unit_tests/sema/template_alias_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -verify -fsyntax-only -dump-symbols %s | %filecheck %s
 
 template <typename Key, typename Value>
 struct HashMap {

--- a/tests/unit_tests/sema/template_base_type_param_01.cc
+++ b/tests/unit_tests/sema/template_base_type_param_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <typename _Tp>

--- a/tests/unit_tests/sema/template_base_type_param_02.cc
+++ b/tests/unit_tests/sema/template_base_type_param_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -verify -fsyntax-only -dump-symbols %s | %filecheck %s
 // expected-no-diagnostics
 
 // Template class with explicit type parameter base - instantiation test.

--- a/tests/unit_tests/sema/template_base_type_param_03.cc
+++ b/tests/unit_tests/sema/template_base_type_param_03.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct A {

--- a/tests/unit_tests/sema/template_cache_equiv_constexpr_01.cc
+++ b/tests/unit_tests/sema/template_cache_equiv_constexpr_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -dump-symbols %s | %filecheck %s
 
 template <int N>
 struct Box {};

--- a/tests/unit_tests/sema/template_cache_equiv_typealias_01.cc
+++ b/tests/unit_tests/sema/template_cache_equiv_typealias_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -dump-symbols %s | %filecheck %s
 
 template <class T>
 struct Box {};

--- a/tests/unit_tests/sema/template_cache_pack_symbol_dump_01.cc
+++ b/tests/unit_tests/sema/template_cache_pack_symbol_dump_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -dump-symbols %s | %filecheck %s
 
 template <typename... Ts>
 struct Pack {};

--- a/tests/unit_tests/sema/template_cache_symbol_dump_01.cc
+++ b/tests/unit_tests/sema/template_cache_symbol_dump_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -dump-symbols %s | %filecheck %s
 
 template <typename T>
 struct Box {};

--- a/tests/unit_tests/sema/template_class_01.cc
+++ b/tests/unit_tests/sema/template_class_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -verify -fsyntax-only -dump-symbols %s | %filecheck %s
 
 template <typename T>
 struct A {

--- a/tests/unit_tests/sema/template_class_02.cc
+++ b/tests/unit_tests/sema/template_class_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -verify -fsyntax-only -dump-symbols %s | %filecheck %s
 
 namespace std {
 

--- a/tests/unit_tests/sema/template_class_03.cc
+++ b/tests/unit_tests/sema/template_class_03.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -dump-symbols %s | %filecheck %s
 
 template <typename T>
 struct X {

--- a/tests/unit_tests/sema/template_class_04.cc
+++ b/tests/unit_tests/sema/template_class_04.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <typename Key, typename Value>
 struct X {

--- a/tests/unit_tests/sema/template_class_05.cc
+++ b/tests/unit_tests/sema/template_class_05.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -dump-symbols %s | %filecheck %s
 
 template <typename T>
 struct Outer {

--- a/tests/unit_tests/sema/template_class_06.cc
+++ b/tests/unit_tests/sema/template_class_06.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -dump-symbols %s | %filecheck %s
 
 template <typename X>
 struct A {

--- a/tests/unit_tests/sema/template_cond_trait_01.cc
+++ b/tests/unit_tests/sema/template_cond_trait_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class _Tp, _Tp _Xp>

--- a/tests/unit_tests/sema/template_constexpr_member_access_01.cc
+++ b/tests/unit_tests/sema/template_constexpr_member_access_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class T>

--- a/tests/unit_tests/sema/template_deduction_basic_01.cc
+++ b/tests/unit_tests/sema/template_deduction_basic_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class T>

--- a/tests/unit_tests/sema/template_deduction_const_ref_01.cc
+++ b/tests/unit_tests/sema/template_deduction_const_ref_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <typename T>

--- a/tests/unit_tests/sema/template_deduction_const_rref_01.cc
+++ b/tests/unit_tests/sema/template_deduction_const_rref_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class T>

--- a/tests/unit_tests/sema/template_deduction_const_rref_02.cc
+++ b/tests/unit_tests/sema/template_deduction_const_rref_02.cc
@@ -1,4 +1,4 @@
-// RUN: not %cxx -fcheck %s
+// RUN: not %cxx -fsyntax-only %s
 
 template <class T>
 void crref(const T&&) {}

--- a/tests/unit_tests/sema/template_deduction_default_args_01.cc
+++ b/tests/unit_tests/sema/template_deduction_default_args_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <typename T, typename U = int>

--- a/tests/unit_tests/sema/template_deduction_explicit_args_01.cc
+++ b/tests/unit_tests/sema/template_deduction_explicit_args_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class T, class U>

--- a/tests/unit_tests/sema/template_deduction_forwarding_ref_01.cc
+++ b/tests/unit_tests/sema/template_deduction_forwarding_ref_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class T>

--- a/tests/unit_tests/sema/template_deduction_multiple_params_01.cc
+++ b/tests/unit_tests/sema/template_deduction_multiple_params_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class T>

--- a/tests/unit_tests/sema/template_deduction_pack_01.cc
+++ b/tests/unit_tests/sema/template_deduction_pack_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class... Ts>

--- a/tests/unit_tests/sema/template_deduction_partial_explicit_01.cc
+++ b/tests/unit_tests/sema/template_deduction_partial_explicit_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <typename R, typename T>

--- a/tests/unit_tests/sema/template_deduction_pointer_01.cc
+++ b/tests/unit_tests/sema/template_deduction_pointer_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class T>

--- a/tests/unit_tests/sema/template_deduction_pointer_02.cc
+++ b/tests/unit_tests/sema/template_deduction_pointer_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class T>

--- a/tests/unit_tests/sema/template_deduction_ref_cv_01.cc
+++ b/tests/unit_tests/sema/template_deduction_ref_cv_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class T>

--- a/tests/unit_tests/sema/template_default_args_substitution_01.cc
+++ b/tests/unit_tests/sema/template_default_args_substitution_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class T = int, int N = 4>

--- a/tests/unit_tests/sema/template_default_pack_nttp_sfinae_01.cc
+++ b/tests/unit_tests/sema/template_default_pack_nttp_sfinae_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class... Ts, int N = sizeof...(Ts)>

--- a/tests/unit_tests/sema/template_dep_class_template_arg_01.cc
+++ b/tests/unit_tests/sema/template_dep_class_template_arg_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class A, class B>

--- a/tests/unit_tests/sema/template_dep_explicit_specifier_01.cc
+++ b/tests/unit_tests/sema/template_dep_explicit_specifier_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct check {

--- a/tests/unit_tests/sema/template_dep_member_access_01.cc
+++ b/tests/unit_tests/sema/template_dep_member_access_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class T>

--- a/tests/unit_tests/sema/template_dep_subscript_01.cc
+++ b/tests/unit_tests/sema/template_dep_subscript_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class T, int N>

--- a/tests/unit_tests/sema/template_explicit_condition_eval_01.cc
+++ b/tests/unit_tests/sema/template_explicit_condition_eval_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <bool B>

--- a/tests/unit_tests/sema/template_explicit_nttp_after_pack_01.cc
+++ b/tests/unit_tests/sema/template_explicit_nttp_after_pack_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <int N, class... Ts>

--- a/tests/unit_tests/sema/template_explicit_wrong_kind_01.cc
+++ b/tests/unit_tests/sema/template_explicit_wrong_kind_01.cc
@@ -1,4 +1,4 @@
-// RUN: not %cxx -fcheck %s
+// RUN: not %cxx -fsyntax-only %s
 
 template <int... Ns, class U>
 auto wrong_kind(U) -> char;

--- a/tests/unit_tests/sema/template_fwd_default_args_01.cc
+++ b/tests/unit_tests/sema/template_fwd_default_args_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // Default template arguments from forward declarations should be
 // carried over to the definition when not repeated.

--- a/tests/unit_tests/sema/template_fwd_default_args_02.cc
+++ b/tests/unit_tests/sema/template_fwd_default_args_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class T = int>

--- a/tests/unit_tests/sema/template_fwddecl_get_01.cc
+++ b/tests/unit_tests/sema/template_fwddecl_get_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 using size_t = decltype(sizeof(int));

--- a/tests/unit_tests/sema/template_fwddecl_swap_01.cc
+++ b/tests/unit_tests/sema/template_fwddecl_swap_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <bool, class T = void>

--- a/tests/unit_tests/sema/template_lambda_01.cc
+++ b/tests/unit_tests/sema/template_lambda_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // Template lambda IIFE with non-type parameter: static_assert fires on
 // instantiation with the default argument _False=false.

--- a/tests/unit_tests/sema/template_member_call_01.cc
+++ b/tests/unit_tests/sema/template_member_call_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class T>

--- a/tests/unit_tests/sema/template_member_ctor_mangle_01.cc
+++ b/tests/unit_tests/sema/template_member_ctor_mangle_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 namespace std {

--- a/tests/unit_tests/sema/template_nns_alias_base_01.cc
+++ b/tests/unit_tests/sema/template_nns_alias_base_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct A {};

--- a/tests/unit_tests/sema/template_nothrow_assignable_01.cc
+++ b/tests/unit_tests/sema/template_nothrow_assignable_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class _Tp, _Tp _Xp>

--- a/tests/unit_tests/sema/template_nttp_non_constexpr_diag_01.cc
+++ b/tests/unit_tests/sema/template_nttp_non_constexpr_diag_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck -fstrict-templates %s
+// RUN: %cxx -verify -fsyntax-only -fstrict-templates %s
 
 template <int N>
 struct Box {};

--- a/tests/unit_tests/sema/template_out_of_line_01.cc
+++ b/tests/unit_tests/sema/template_out_of_line_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <typename T>
 struct Box {

--- a/tests/unit_tests/sema/template_out_of_line_02.cc
+++ b/tests/unit_tests/sema/template_out_of_line_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <typename T>
 struct Pair {

--- a/tests/unit_tests/sema/template_out_of_line_03.cc
+++ b/tests/unit_tests/sema/template_out_of_line_03.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <typename K, typename V>
 struct Map {

--- a/tests/unit_tests/sema/template_partial_ambiguous_diag_01.cc
+++ b/tests/unit_tests/sema/template_partial_ambiguous_diag_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <class T, class U>
 struct S;

--- a/tests/unit_tests/sema/template_partial_decl_order_tiebreak_01.cc
+++ b/tests/unit_tests/sema/template_partial_decl_order_tiebreak_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <int A, int B>
 struct pick_n {

--- a/tests/unit_tests/sema/template_partial_nested_pack_head_01.cc
+++ b/tests/unit_tests/sema/template_partial_nested_pack_head_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class T>

--- a/tests/unit_tests/sema/template_partial_nested_specificity_01.cc
+++ b/tests/unit_tests/sema/template_partial_nested_specificity_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class T>

--- a/tests/unit_tests/sema/template_partial_nested_tiebreak_01.cc
+++ b/tests/unit_tests/sema/template_partial_nested_tiebreak_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class T>

--- a/tests/unit_tests/sema/template_partial_nontype_repeat_01.cc
+++ b/tests/unit_tests/sema/template_partial_nontype_repeat_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <int N, class T>

--- a/tests/unit_tests/sema/template_partial_order_01.cc
+++ b/tests/unit_tests/sema/template_partial_order_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <typename T, typename U>
 struct S {

--- a/tests/unit_tests/sema/template_partial_pack_vs_nopack_01.cc
+++ b/tests/unit_tests/sema/template_partial_pack_vs_nopack_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <class... Ts>
 struct TypeList {};

--- a/tests/unit_tests/sema/template_partial_spec_01.cc
+++ b/tests/unit_tests/sema/template_partial_spec_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <class... _Types>
 struct __type_list {};

--- a/tests/unit_tests/sema/template_partial_tiebreak_01.cc
+++ b/tests/unit_tests/sema/template_partial_tiebreak_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <typename T, typename U>
 struct S;

--- a/tests/unit_tests/sema/template_sfinae_enable_if_01.cc
+++ b/tests/unit_tests/sema/template_sfinae_enable_if_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <bool B, class T = void>

--- a/tests/unit_tests/sema/template_sfinae_member_01.cc
+++ b/tests/unit_tests/sema/template_sfinae_member_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct false_t {};

--- a/tests/unit_tests/sema/template_sfinae_mixed_01.cc
+++ b/tests/unit_tests/sema/template_sfinae_mixed_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <bool B, class T = void>

--- a/tests/unit_tests/sema/template_sfinae_pack_deduction_01.cc
+++ b/tests/unit_tests/sema/template_sfinae_pack_deduction_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class... Ts, class U>

--- a/tests/unit_tests/sema/template_sfinae_substitution_01.cc
+++ b/tests/unit_tests/sema/template_sfinae_substitution_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct has_type_member {

--- a/tests/unit_tests/sema/template_sfinae_substitution_02.cc
+++ b/tests/unit_tests/sema/template_sfinae_substitution_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct with_type {

--- a/tests/unit_tests/sema/template_sfinae_substitution_03.cc
+++ b/tests/unit_tests/sema/template_sfinae_substitution_03.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct with_size_type {

--- a/tests/unit_tests/sema/template_sfinae_void_ref_01.cc
+++ b/tests/unit_tests/sema/template_sfinae_void_ref_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct false_type {

--- a/tests/unit_tests/sema/template_specialization_fwd_decl_01.cc
+++ b/tests/unit_tests/sema/template_specialization_fwd_decl_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <class T>

--- a/tests/unit_tests/sema/template_ttp_01.cc
+++ b/tests/unit_tests/sema/template_ttp_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -verify -fsyntax-only -dump-symbols %s | %filecheck %s
 
 template <typename T>
 struct Holder {

--- a/tests/unit_tests/sema/template_typename_nonscope_diag_01.cc
+++ b/tests/unit_tests/sema/template_typename_nonscope_diag_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <typename T>
 struct S {

--- a/tests/unit_tests/sema/template_var_01.cc
+++ b/tests/unit_tests/sema/template_var_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck -dump-symbols %s
+// RUN: %cxx -verify -fsyntax-only -dump-symbols %s
 
 template <typename T>
 constexpr bool is_integral_v = __is_integral(T);

--- a/tests/unit_tests/sema/trailing_return_type_01.cc
+++ b/tests/unit_tests/sema/trailing_return_type_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -verify -fsyntax-only -dump-symbols %s | %filecheck %s
 
 struct list {
   using value_type = int;

--- a/tests/unit_tests/sema/trailing_return_type_02.cc
+++ b/tests/unit_tests/sema/trailing_return_type_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -verify -fsyntax-only -dump-symbols %s | %filecheck %s
 
 auto f(int x) -> decltype(x);
 auto g(int x, decltype(x)* y) -> decltype(y);

--- a/tests/unit_tests/sema/type_construction_builtin_01.cc
+++ b/tests/unit_tests/sema/type_construction_builtin_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 bool f() { return bool(true); }

--- a/tests/unit_tests/sema/type_pack_element_01.cc
+++ b/tests/unit_tests/sema/type_pack_element_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // expected-no-diagnostics
 

--- a/tests/unit_tests/sema/type_traits_01.cc
+++ b/tests/unit_tests/sema/type_traits_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 //
 // is_void trait

--- a/tests/unit_tests/sema/type_traits_02.cc
+++ b/tests/unit_tests/sema/type_traits_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct Empty {};
 

--- a/tests/unit_tests/sema/type_traits_03.cc
+++ b/tests/unit_tests/sema/type_traits_03.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct A { int m; };
 struct B { B(B const&) {} };

--- a/tests/unit_tests/sema/type_traits_overload_set.cc
+++ b/tests/unit_tests/sema/type_traits_overload_set.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct BothDefaulted {
   BothDefaulted& operator=(const BothDefaulted&) = default;

--- a/tests/unit_tests/sema/type_traits_template.cc
+++ b/tests/unit_tests/sema/type_traits_template.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct TrivialBoth {
   TrivialBoth& operator=(const TrivialBoth&) = default;

--- a/tests/unit_tests/sema/typeid_ok_01.cc
+++ b/tests/unit_tests/sema/typeid_ok_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 int value = 42;
 

--- a/tests/unit_tests/sema/typeid_unresolved_id_01.cc
+++ b/tests/unit_tests/sema/typeid_unresolved_id_01.cc
@@ -1,3 +1,3 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 auto m = typeid(missing_identifier); // expected-error {{use of undeclared identifier 'missing_identifier'}}

--- a/tests/unit_tests/sema/typename_nns_alias_resolve_01.cc
+++ b/tests/unit_tests/sema/typename_nns_alias_resolve_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct A {};

--- a/tests/unit_tests/sema/unary_minus_01.cc
+++ b/tests/unit_tests/sema/unary_minus_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 auto main() -> int {
   static_assert(__is_same(decltype(-'a'), int));

--- a/tests/unit_tests/sema/unary_plus_01.cc
+++ b/tests/unit_tests/sema/unary_plus_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 auto main() -> int {
   static_assert(__is_same(decltype(+'a'), int));

--- a/tests/unit_tests/sema/union_zero_init_01.c
+++ b/tests/unit_tests/sema/union_zero_init_01.c
@@ -1,4 +1,4 @@
-// RUN: %cxx -toolchain macos -verify -fcheck %s
+// RUN: %cxx -toolchain macos -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 typedef union {

--- a/tests/unit_tests/sema/unresolved_call_identifier_01.cc
+++ b/tests/unit_tests/sema/unresolved_call_identifier_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // expected-error@1 {{use of undeclared identifier 'missing'}}
 int x = missing(42);

--- a/tests/unit_tests/sema/unresolved_qualified_id_01.cc
+++ b/tests/unit_tests/sema/unresolved_qualified_id_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 namespace ns {
 int y;

--- a/tests/unit_tests/sema/unresolved_qualified_id_02.cc
+++ b/tests/unit_tests/sema/unresolved_qualified_id_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <typename T>

--- a/tests/unit_tests/sema/user_conversion_01.cc
+++ b/tests/unit_tests/sema/user_conversion_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct String {
   String(const char* s) {}

--- a/tests/unit_tests/sema/user_conversion_02.cc
+++ b/tests/unit_tests/sema/user_conversion_02.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct A {
   A(int x) {}

--- a/tests/unit_tests/sema/using_decl_01.cc
+++ b/tests/unit_tests/sema/using_decl_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -fsyntax-only -dump-symbols %s | %filecheck %s
 
 int printf(const char*, ...);
 

--- a/tests/unit_tests/sema/variable_redecl_array_complete_01.cc
+++ b/tests/unit_tests/sema/variable_redecl_array_complete_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 extern int data[];

--- a/tests/unit_tests/sema/variable_redecl_array_conflict_01.cc
+++ b/tests/unit_tests/sema/variable_redecl_array_conflict_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 int items[2];
 

--- a/tests/unit_tests/sema/variable_redecl_conflict_01.cc
+++ b/tests/unit_tests/sema/variable_redecl_conflict_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 int x;
 

--- a/tests/unit_tests/sema/variable_template_partial_spec_01.cc
+++ b/tests/unit_tests/sema/variable_template_partial_spec_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 // Variable template partial specialization: base case and recursive evaluation
 template <long _Xp, long _Yp>

--- a/tests/unit_tests/sema/variadic_abbrev_func_01.cc
+++ b/tests/unit_tests/sema/variadic_abbrev_func_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 constexpr int count_abbrev(auto... args) { return sizeof...(args); }
 

--- a/tests/unit_tests/sema/variadic_base_01.cc
+++ b/tests/unit_tests/sema/variadic_base_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct TagA {
   int a;

--- a/tests/unit_tests/sema/variadic_expand_01.cc
+++ b/tests/unit_tests/sema/variadic_expand_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <int... Ns>
 constexpr int nttp_count() {

--- a/tests/unit_tests/sema/variadic_fold_01.cc
+++ b/tests/unit_tests/sema/variadic_fold_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <int... Ns>
 constexpr int sum_left() {

--- a/tests/unit_tests/sema/variadic_func_deduction_01.cc
+++ b/tests/unit_tests/sema/variadic_func_deduction_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <typename... Ts>
 constexpr int count(Ts... args) {

--- a/tests/unit_tests/sema/variadic_pack_01.cc
+++ b/tests/unit_tests/sema/variadic_pack_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 template <typename... Ts>
 constexpr int count() {

--- a/tests/unit_tests/sema/virtual_functions_01.cc
+++ b/tests/unit_tests/sema/virtual_functions_01.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck -dump-symbols %s | %filecheck %s
+// RUN: %cxx -verify -fsyntax-only -dump-symbols %s | %filecheck %s
 
 struct Base {
   virtual void f();

--- a/tests/unit_tests/sema/virtual_functions_02.cc
+++ b/tests/unit_tests/sema/virtual_functions_02.cc
@@ -1,5 +1,5 @@
 // clang-format off
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 
 struct NoBase {
   void f() override; // expected-error {{'f' marked 'override' but does not override any member function}}

--- a/tests/unit_tests/sema/wasm_stdlib_01.cc
+++ b/tests/unit_tests/sema/wasm_stdlib_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -toolchain wasm32 -fcheck %s
+// RUN: %cxx -toolchain wasm32 -fsyntax-only %s
 
 #include <bit>
 #include <cassert>

--- a/tests/unit_tests/sema/wasm_stdlib_01.cc
+++ b/tests/unit_tests/sema/wasm_stdlib_01.cc
@@ -27,6 +27,8 @@
 #include <initializer_list>
 #include <limits>
 #include <new>
+#include <string_view>
+#include <tuple>
 #include <type_traits>
 #include <typeindex>
 #include <typeinfo>

--- a/tests/unit_tests/sema/wasm_stdlib_c++14.cc
+++ b/tests/unit_tests/sema/wasm_stdlib_c++14.cc
@@ -84,7 +84,6 @@
 #endif
 
 #include <queue>
-// #include <random>
 #include <ranges>
 #include <ratio>
 #include <regex>
@@ -113,7 +112,7 @@
 #include <streambuf>
 #include <string>
 #include <string_view>
-// #include <strstream>
+#include <strstream>
 #include <syncstream>
 #include <system_error>
 #ifndef _LIBCPP_HAS_NO_THREADS
@@ -128,6 +127,9 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
-// #include <valarray>
 #include <variant>
 #include <vector>
+
+//
+// #include <random>
+// #include <valarray>

--- a/tests/unit_tests/sema/wasm_stdlib_c++14.cc
+++ b/tests/unit_tests/sema/wasm_stdlib_c++14.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -toolchain wasm32 -fcheck %s
+// RUN: %cxx -toolchain wasm32 -fsyntax-only %s
 
 #undef __cplusplus
 #define __cplusplus 201402L

--- a/tests/unit_tests/sema/while_condition_decl_01.cc
+++ b/tests/unit_tests/sema/while_condition_decl_01.cc
@@ -1,4 +1,4 @@
-// RUN: %cxx -verify -fcheck %s
+// RUN: %cxx -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 struct Node {


### PR DESCRIPTION
Remove fuzzy template lookup mode from, improve constraints,
expose options to the JS api to set the c++ language standard,
deprecate use of -fcheck in favor of -fsyntax-only (still off by default).